### PR TITLE
The status of returned wave was never set to "Handle"

### DIFF
--- a/org.jrebirth.af/api/src/main/java/org/jrebirth/af/api/wave/Wave.java
+++ b/org.jrebirth.af/api/src/main/java/org/jrebirth/af/api/wave/Wave.java
@@ -53,7 +53,7 @@ public interface Wave {
         /** The wave has just been cancelled. */
         Cancelled,
 
-        /** The wave has just been consumed. */
+        /** The wave is being consumed. */
         Consumed,
 
         /** The wave has been performed by all handlers. */

--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/link/LinkMessages.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/link/LinkMessages.java
@@ -98,6 +98,9 @@ public interface LinkMessages extends MessageContainer {
     /** "NB consumes : {0}". */
     MessageItem NOTIFIER_CONSUMES = create(new LogMessage("jrebirth.link.notifierConsumes", JRLevel.Info, JRebirthMarkers.WAVE));
 
+    /** "NB consumes : {0}". */
+    MessageItem NOTIFIER_HANDLES = create(new LogMessage("jrebirth.link.notifierHandles", JRLevel.Info, JRebirthMarkers.WAVE));
+
     /** "Error while handling a wave". */
     MessageItem WAVE_HANDLING_ERROR = create(new LogMessage("jrebirth.link.waveHandlingError", JRLevel.Error, JRebirthMarkers.WAVE));
 

--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/link/NotifierBase.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/link/NotifierBase.java
@@ -230,6 +230,8 @@ public class NotifierBase extends AbstractGlobalReady implements Notifier, LinkM
      * @throws WaveException if wave dispatching fails
      */
     private void processUndefinedWave(final Wave wave) throws WaveException {
+        LOGGER.info(NOTIFIER_CONSUMES, wave.toString());
+        wave.status(Status.Consumed);
 
         // Retrieve all interested object from the map
         if (this.notifierMap.containsKey(wave.waveType())) {
@@ -262,8 +264,8 @@ public class NotifierBase extends AbstractGlobalReady implements Notifier, LinkM
             }
         }
 
-        LOGGER.info(NOTIFIER_CONSUMES, wave.toString());
-        wave.status(Status.Consumed);
+        LOGGER.info(NOTIFIER_HANDLES, wave.toString());
+        wave.status(Status.Handled);
 
     }
 

--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/service/ServiceMessages.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/service/ServiceMessages.java
@@ -44,6 +44,9 @@ public interface ServiceMessages extends MessageContainer {
     /** "{0} Consumes wave {1}" . */
     MessageItem SERVICE_TASK_RETURN_CONSUMES = create(new LogMessage("jrebirth.service.serviceTaskReturnConsumes", JRLevel.Trace, JRebirthMarkers.SERVICE));
 
+    /** "{0} Consumes wave {1}" . */
+    MessageItem SERVICE_TASK_RETURN_HANDLES = create(new LogMessage("jrebirth.service.serviceTaskReturnHandles", JRLevel.Trace, JRebirthMarkers.SERVICE));
+
     /** "{0} experience a service task failure for wave {1}" . */
     MessageItem SERVICE_TASK_HAS_FAILED = create(new LogMessage("jrebirth.service.serviceTaskHasFailed", JRLevel.Error, JRebirthMarkers.SERVICE));
 

--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/service/ServiceTaskReturnWaveListener.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/service/ServiceTaskReturnWaveListener.java
@@ -83,9 +83,9 @@ public final class ServiceTaskReturnWaveListener implements WaveListener, Servic
     @Override
     public void waveHandled(final Wave wave) {
         if (wave.relatedWave() != null) {
-            // Return wave has been consumed, so the triggered wave can be consumed too
-            LOGGER.trace(SERVICE_TASK_RETURN_CONSUMES, wave.fromClass().getSimpleName(), wave.relatedWave().toString());
-            wave.relatedWave().status(Status.Consumed);
+            // Return wave has been handled, so the triggered wave can be handled too
+            LOGGER.trace(SERVICE_TASK_RETURN_HANDLES, wave.fromClass().getSimpleName(), wave.relatedWave().toString());
+            wave.relatedWave().status(Status.Handled);
         }
     }
 

--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/wave/Builders.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/wave/Builders.java
@@ -20,6 +20,7 @@ package org.jrebirth.af.core.wave;
 import java.util.List;
 
 import org.jrebirth.af.api.command.Command;
+import org.jrebirth.af.api.service.Service;
 import org.jrebirth.af.api.wave.Wave;
 import org.jrebirth.af.api.wave.WaveGroup;
 import org.jrebirth.af.api.wave.contract.WaveData;
@@ -69,6 +70,17 @@ public interface Builders {
      */
     static Wave callCommand(final Class<? extends Command> commandClass) {
         return wave().waveGroup(WaveGroup.CALL_COMMAND).componentClass(commandClass);
+    }
+
+    /**
+     * Build a fresh Wave use to call the given service.
+     *
+     * @param serviceClass the service class
+     *
+     * @return the wave
+     */
+    static Wave returnData(final Class<? extends Service> serviceClass) {
+        return wave().waveGroup(WaveGroup.RETURN_DATA).componentClass(serviceClass);
     }
 
     /**

--- a/org.jrebirth.af/core/src/main/resources/Messages_rb.properties
+++ b/org.jrebirth.af/core/src/main/resources/Messages_rb.properties
@@ -132,6 +132,7 @@ jrebirth.link.modelNotFoundError=Cannot get the right Model to process the wave 
 jrebirth.link.modelNotFoundMessage=Cannot get the right Model to process the wave
 jrebirth.link.noWaveListener=No Listener attached for wave type : {0}
 jrebirth.link.notifierConsumes=NB consumes : {0}
+jrebirth.link.notifierHandles=NB handles : {0}
 jrebirth.link.waveHandlingError=Error while handling a wave
 ##
 #### Wave
@@ -152,6 +153,7 @@ jrebirth.service.noWaveTypeDefined=Wave processed without any wave type for serv
 ####	ServiceTaskReturnWaveListener
 ##
 jrebirth.service.serviceTaskReturnConsumes={0} Consumes wave {1}||Trace||SERVICE
+jrebirth.service.serviceTaskReturnHandles={0} Handles wave {1}||Trace||SERVICE
 ##
 ####	ServiceTask
 ##


### PR DESCRIPTION
Commit 083f62d:
- Fix issue on ServiceTaskReturnWaveListener
- As the returned wave is processed as Undefined wave I saw the consumed/handled new status cycle was not respected here

Commit 01cb785:
- allow to do Builders.returnData() just simple as Builders.callCommand() 

Next time I'll do one pull request per issue, did not know I had to send all commits in once.
