### PR TITLE
Add getter to retrieve the source wave of a ServiceTask

### DIFF
--- a/org.jrebirth.af/api/src/main/java/org/jrebirth/af/api/service/ServiceTask.java
+++ b/org.jrebirth.af/api/src/main/java/org/jrebirth/af/api/service/ServiceTask.java
@@ -18,6 +18,7 @@
 package org.jrebirth.af.api.service;
 
 import javafx.concurrent.Worker;
+import org.jrebirth.af.api.wave.Wave;
 
 /**
  * The class <strong>ServiceTask</strong>.
@@ -43,6 +44,11 @@ public interface ServiceTask<T> extends Worker<T> {
      * Remove the task from the service pending list
      */
     void taskAchieved();
+
+    /**
+     * @return the wave associated to this service task
+     */
+    Wave getAssociatedWave();
 
     /**
      * Check if the task has enough progressed according to the given threshold.

--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/service/ServiceTaskBase.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/service/ServiceTaskBase.java
@@ -17,14 +17,7 @@
  */
 package org.jrebirth.af.core.service;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-
 import javafx.concurrent.Task;
-
 import org.jrebirth.af.api.command.Command;
 import org.jrebirth.af.api.concurrent.JRebirthRunnable;
 import org.jrebirth.af.api.concurrent.Priority;
@@ -43,6 +36,12 @@ import org.jrebirth.af.core.wave.Builders;
 import org.jrebirth.af.core.wave.JRebirthItems;
 import org.jrebirth.af.core.wave.JRebirthWaves;
 import org.jrebirth.af.core.wave.WaveItemBase;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The class <strong>ServiceTask</strong>.
@@ -324,6 +323,14 @@ public final class ServiceTaskBase<T> extends Task<T> implements JRebirthRunnabl
     public void taskAchieved() {
         // We can now remove the pending task (even if the return wave isn't processed TO CHECK)
         this.service.removePendingTask(this.wave.getWUID());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Wave getAssociatedWave() {
+        return this.wave;
     }
 
     /**


### PR DESCRIPTION
I added a conveniant method to retrieve the wave from a ServiceTask.

First idea was to add the getter only in ServiceTaskBase but it doesn't seem problematic to add the getter in the ServiceTask interface too. As I see a ServiceTask is strongly dependant of the wave used to returnData.

Here are more informations about why I needed this method:
- I want to monitored all (almost) serviceTask running in the application
- So for each services I want to monitor i'm listening the pendingTaskList
- All listened tasks are binded in a big collection (which can be used in the view)
- But our services method can have extra-informations (we have custom annotations) that we need.
- These annotatione can be retrieve through the wave in the serviceTask

```java
final Method method = ClassUtility.getMethodByName(service.getClass(), ClassUtility.underscoreToCamelCase(wave.waveType().toString()));
```

P.S. : as you will see the imports have been reorganized. This is an automatic feature of my IDE (intellij). In my previous pull request I was taking care to disable this feature before commit, but if it's not a problem to you I will let it activate for the next times.