### PR TITLE
Fix a NoSuchElementException and the method handler name construction in WaveTypeBase

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Maven coordinates:
     <dependency>
         <groupId>org.jrebirth.af</groupId>
         <artifactId>core</artifactId>
-        <version>8.0.3</version>
+        <version>8.1.0-SNAPSHOT</version>
     </dependency>
 
 ## Documentation

--- a/org.jrebirth.af/api/pom.xml
+++ b/org.jrebirth.af/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 	</parent>
 	
 	<groupId>org.jrebirth.af</groupId>

--- a/org.jrebirth.af/api/pom.xml
+++ b/org.jrebirth.af/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 	</parent>
 	
 	<groupId>org.jrebirth.af</groupId>

--- a/org.jrebirth.af/api/src/main/java/org/jrebirth/af/api/service/ServiceTask.java
+++ b/org.jrebirth.af/api/src/main/java/org/jrebirth/af/api/service/ServiceTask.java
@@ -18,6 +18,7 @@
 package org.jrebirth.af.api.service;
 
 import javafx.concurrent.Worker;
+import org.jrebirth.af.api.wave.Wave;
 
 /**
  * The class <strong>ServiceTask</strong>.
@@ -43,6 +44,11 @@ public interface ServiceTask<T> extends Worker<T> {
      * Remove the task from the service pending list
      */
     void taskAchieved();
+
+    /**
+     * @return the wave associated to this service task
+     */
+    Wave getAssociatedWave();
 
     /**
      * Check if the task has enough progressed according to the given threshold.

--- a/org.jrebirth.af/archetype/pom.xml
+++ b/org.jrebirth.af/archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/org.jrebirth.af/archetype/pom.xml
+++ b/org.jrebirth.af/archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/org.jrebirth.af/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/org.jrebirth.af/archetype/src/main/resources/archetype-resources/pom.xml
@@ -234,13 +234,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>preloader</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/org.jrebirth.af/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/org.jrebirth.af/archetype/src/main/resources/archetype-resources/pom.xml
@@ -234,13 +234,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>preloader</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/org.jrebirth.af/component/pom.xml
+++ b/org.jrebirth.af/component/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -19,13 +19,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 			<optional>true</optional>
 			<scope>provided</scope>
 		</dependency>
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>preloader</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/org.jrebirth.af/component/pom.xml
+++ b/org.jrebirth.af/component/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -19,13 +19,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 			<optional>true</optional>
 			<scope>provided</scope>
 		</dependency>
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>preloader</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/org.jrebirth.af/core/pom.xml
+++ b/org.jrebirth.af/core/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -19,13 +19,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>api</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>preloader</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/org.jrebirth.af/core/pom.xml
+++ b/org.jrebirth.af/core/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -19,13 +19,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>api</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>preloader</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/key/ClassKey.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/key/ClassKey.java
@@ -101,7 +101,7 @@ public class ClassKey<R> implements UniqueKey<R> {
     @SuppressWarnings("unchecked")
     @Override
     public boolean equals(final Object obj) {
-        return obj instanceof ClassKey && this.getClassField().equals(((ClassKey<R>) obj).getClassField());
+        return obj != null && obj.getClass() == ClassKey.class && this.getClassField().equals(((ClassKey<R>) obj).getClassField());
     }
 
     /**

--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/service/ServiceTaskBase.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/service/ServiceTaskBase.java
@@ -17,14 +17,7 @@
  */
 package org.jrebirth.af.core.service;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-
 import javafx.concurrent.Task;
-
 import org.jrebirth.af.api.command.Command;
 import org.jrebirth.af.api.concurrent.JRebirthRunnable;
 import org.jrebirth.af.api.concurrent.Priority;
@@ -43,6 +36,12 @@ import org.jrebirth.af.core.wave.Builders;
 import org.jrebirth.af.core.wave.JRebirthItems;
 import org.jrebirth.af.core.wave.JRebirthWaves;
 import org.jrebirth.af.core.wave.WaveItemBase;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The class <strong>ServiceTask</strong>.
@@ -324,6 +323,14 @@ public final class ServiceTaskBase<T> extends Task<T> implements JRebirthRunnabl
     public void taskAchieved() {
         // We can now remove the pending task (even if the return wave isn't processed TO CHECK)
         this.service.removePendingTask(this.wave.getWUID());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Wave getAssociatedWave() {
+        return this.wave;
     }
 
     /**

--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/wave/WaveBase.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/wave/WaveBase.java
@@ -410,10 +410,15 @@ public class WaveBase implements Wave, LinkMessages {
 
     /**
      * {@inheritDoc}
+     * 
+     * Don't use the returned list to add WaveBean.
      */
     @Override
     public List<WaveBean> waveBeanList() {
-        return new ArrayList<>(this.waveBeanMap.values());
+        if (this.waveBeanMap != null && !this.waveBeanMap.isEmpty()) {
+            return new ArrayList<>(this.waveBeanMap.values());
+        }
+        return new ArrayList<>();
     }
 
     /**

--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/wave/WaveTypeBase.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/wave/WaveTypeBase.java
@@ -41,7 +41,8 @@ public final class WaveTypeBase implements WaveType {
     /** The unique identifier of the wave type. */
     private int uid;
 
-    /** The action to performed, basically the name of the method to call. */
+    /** The action to performed, basically the name of the method to call.
+     * The keyword "DO_" (by default see {@link JRebirthParameters.WAVE_HANDLER_PREFIX}) will be prepended to the action name to generate the handler method */
     private String action;
 
     /** Define arguments types to use. */
@@ -81,10 +82,6 @@ public final class WaveTypeBase implements WaveType {
 
     /**
      * Default constructor.
-     *
-     * @param action The action to perform, "DO_" (by default see {@link JRebirthParameters.WAVE_HANDLER_PREFIX}) keyword will be prepended to the action name to generate the handler method
-     *
-     * @param waveItems the list of #WaveItem{@link WaveItem} required by this wave
      */
     WaveTypeBase() {
 
@@ -93,9 +90,7 @@ public final class WaveTypeBase implements WaveType {
     }
 
     /**
-     * Gets the uid.
-     *
-     * @return Returns the uid.
+     * {@inheritDoc}
      */
     @Override
     public int uid() {
@@ -103,9 +98,7 @@ public final class WaveTypeBase implements WaveType {
     }
 
     /**
-     * Sets the uid.
-     *
-     * @param uid The uid to set.
+     * {@inheritDoc}
      */
     @Override
     public WaveTypeBase uid(final int uid) {
@@ -114,9 +107,7 @@ public final class WaveTypeBase implements WaveType {
     }
 
     /**
-     * Gets the action.
-     *
-     * @return Returns the action.
+     * {@inheritDoc}
      */
     @Override
     public String action() {
@@ -124,32 +115,26 @@ public final class WaveTypeBase implements WaveType {
     }
 
     /**
-     * Sets the uid.
-     *
-     * @param uid The uid to set.
+     * {@inheritDoc}
      */
     @Override
     public WaveTypeBase action(final String action) {
-
         WaveTypeRegistry.store(action, this);
-
-        // The action name will be used to define the name of the wave handler method
-        // Prepend do the the action name to force wave handler method to begin with do (convention parameterizable)
-        this.action = JRebirthParameters.WAVE_HANDLER_PREFIX.get() + action;
-
+        this.action = action;
         return this;
     }
 
     /**
-     * Gets the wave item list.
-     *
-     * @return Returns the waveItemList.
+     * {@inheritDoc}
      */
     @Override
     public List<WaveItem<?>> items() {
         return this.waveItemList;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public WaveTypeBase items(final WaveItem<?>... items) {
         // Add each wave item to manage method argument
@@ -160,9 +145,7 @@ public final class WaveTypeBase implements WaveType {
     }
 
     /**
-     * Gets the action.
-     *
-     * @return Returns the action.
+     * {@inheritDoc}
      */
     @Override
     public String returnAction() {
@@ -170,9 +153,7 @@ public final class WaveTypeBase implements WaveType {
     }
 
     /**
-     * Sets the uid.
-     *
-     * @param uid The uid to set.
+     * {@inheritDoc}
      */
     @Override
     public WaveTypeBase returnAction(final String returnAction) {
@@ -220,7 +201,7 @@ public final class WaveTypeBase implements WaveType {
     public WaveType returnWaveType(final WaveType returnWaveType) {
         this.returnWaveType = returnWaveType;
         this.returnAction = returnWaveType.action();
-        this.returnItem = returnWaveType.items().stream().findFirst().get();
+        this.returnItem = returnWaveType.items().stream().findFirst().orElse(null);
         return this;
     }
 
@@ -275,7 +256,9 @@ public final class WaveTypeBase implements WaveType {
      */
     @Override
     public String toString() {
-        return this.action;
+        // The action name will be used to define the name of the wave handler method
+        // Prepend do before the action name to force wave handler method to begin with do (convention parameterizable)
+        return JRebirthParameters.WAVE_HANDLER_PREFIX.get() + this.action;
     }
 
     /**

--- a/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/key/KeyTest.java
+++ b/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/key/KeyTest.java
@@ -7,11 +7,13 @@ import javafx.scene.Cursor;
 import javafx.scene.layout.BorderPane;
 
 import org.jrebirth.af.api.command.Command;
+import org.jrebirth.af.api.key.UniqueKey;
 import org.jrebirth.af.core.application.TestApplication;
 import org.jrebirth.af.core.command.basic.SwitchFullScreenCommand;
 import org.jrebirth.af.core.command.basic.UpdateCursorCommand;
 import org.jrebirth.af.core.facade.CommandFacade;
 import org.jrebirth.af.core.facade.GlobalFacadeBase;
+import org.jrebirth.af.core.ui.DefaultModel;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -51,6 +53,59 @@ public class KeyTest {
         this.commandFacade = globalFacade.getCommandFacade();
     }
 
+    @Test
+    public void testCrossKeyInequality() {
+        final UniqueKey<DefaultModel> key1 = Key.create(DefaultModel.class);
+        final UniqueKey<DefaultModel> key2 = Key.create(DefaultModel.class, new Object());
+
+        Assert.assertFalse(key1.equals(key2));
+        Assert.assertFalse(key2.equals(key1));
+    }
+
+    @Test
+    public void testClassKeyEquality() {
+        final Object sameObject = new Object();
+
+        final UniqueKey<DefaultModel> key1 = Key.create(DefaultModel.class);
+        final UniqueKey<DefaultModel> key2 = Key.create(DefaultModel.class);
+
+        Assert.assertTrue(key1.equals(key2));
+        Assert.assertTrue(key2.equals(key1));
+    }
+
+    @Test
+    public void testMultitonKeyEquality1() {
+        final Object sameObject = new Object();
+
+        final UniqueKey<DefaultModel> key1 = Key.create(DefaultModel.class, sameObject);
+        final UniqueKey<DefaultModel> key2 = Key.create(DefaultModel.class, sameObject);
+
+        Assert.assertTrue(key1.equals(key2));
+        Assert.assertTrue(key2.equals(key1));
+    }
+
+    @Test
+    public void testMultitonKeyInequality1() {
+
+        final Object sameObject = new Object();
+
+        final UniqueKey<DefaultModel> key1 = Key.create(DefaultModel.class, sameObject, new Object());
+        final UniqueKey<DefaultModel> key2 = Key.create(DefaultModel.class, sameObject);
+
+        Assert.assertFalse(key1.equals(key2));
+        Assert.assertFalse(key2.equals(key1));
+    }
+
+    @Test
+    public void testMultitonKeyInequality2() {
+
+        final UniqueKey<DefaultModel> key1 = Key.create(DefaultModel.class, new Object());
+        final UniqueKey<DefaultModel> key2 = Key.create(DefaultModel.class, new Object());
+
+        Assert.assertFalse(key1.equals(key2));
+        Assert.assertFalse(key2.equals(key1));
+    }
+
     @SuppressWarnings("unused")
     @Test
     public void registerCommandWithKey() {
@@ -69,9 +124,9 @@ public class KeyTest {
         strongList.add(this.commandFacade.retrieve(UpdateCursorCommand.class, Cursor.WAIT, new BorderPane()));
 
         checkComponentCount(UpdateCursorCommand.class, 3);
-        
+
         checkComponentCount(SwitchFullScreenCommand.class, 100_000);
-        
+
         // retain the strong list even method check to avoid compiler optimization that will release item too early
         System.out.println(strongList.size() + " items strongly retained");
     }

--- a/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/wave/WaveTypeTest.java
+++ b/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/wave/WaveTypeTest.java
@@ -1,0 +1,52 @@
+/**
+ * Get more info at : www.jrebirth.org .
+ * Copyright JRebirth.org © 2011-2015
+ * Contact : sebastien.bordes@jrebirth.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jrebirth.af.core.wave;
+
+import junit.framework.Assert;
+import org.jrebirth.af.api.wave.contract.WaveItem;
+import org.jrebirth.af.api.wave.contract.WaveType;
+import org.junit.Test;
+
+
+public class WaveTypeTest {
+
+    @Test
+    public void testTheReturnItemOfReturnWaveType() {
+        WaveType RE_FLUSH = Builders.waveType("RE_FLUSH");
+        WaveType FLUSH = Builders.waveType("FLUSH").returnWaveType(RE_FLUSH);
+
+        Assert.assertTrue(FLUSH.returnWaveType().items().isEmpty());
+        Assert.assertNull(FLUSH.returnItem());
+    }
+
+    @Test
+    public void testHandlerMethodName() {
+        WaveItem RESULT = new WaveItemBase<Object>() {};
+        WaveType RE_FLUSH = Builders.waveType("RE_FLUSH").items(RESULT);
+        WaveType FLUSH = Builders.waveType("FLUSH").returnWaveType(RE_FLUSH).returnItem(RESULT);
+
+        Assert.assertEquals("FLUSH", FLUSH.action());
+        Assert.assertEquals("DO_FLUSH", FLUSH.toString());
+
+        Assert.assertEquals("RE_FLUSH", RE_FLUSH.action());
+        Assert.assertEquals("DO_RE_FLUSH", RE_FLUSH.toString());
+
+        Assert.assertEquals("RE_FLUSH", FLUSH.returnWaveType().action());
+        Assert.assertEquals("DO_RE_FLUSH", FLUSH.returnWaveType().toString());
+    }
+}

--- a/org.jrebirth.af/dialog/pom.xml
+++ b/org.jrebirth.af/dialog/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jrebirth.af</groupId>
@@ -32,12 +32,12 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/org.jrebirth.af/dialog/pom.xml
+++ b/org.jrebirth.af/dialog/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jrebirth.af</groupId>
@@ -32,12 +32,12 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/org.jrebirth.af/distribution/pom.xml
+++ b/org.jrebirth.af/distribution/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/org.jrebirth.af/distribution/pom.xml
+++ b/org.jrebirth.af/distribution/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/org.jrebirth.af/fxform/pom.xml
+++ b/org.jrebirth.af/fxform/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/org.jrebirth.af/fxform/pom.xml
+++ b/org.jrebirth.af/fxform/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/org.jrebirth.af/modular/pom.xml
+++ b/org.jrebirth.af/modular/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jrebirth.af</groupId>
 	<artifactId>modular</artifactId>
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>api</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 		
 	</dependencies>

--- a/org.jrebirth.af/modular/pom.xml
+++ b/org.jrebirth.af/modular/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jrebirth.af</groupId>
 	<artifactId>modular</artifactId>
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>api</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 		
 	</dependencies>

--- a/org.jrebirth.af/pom.xml
+++ b/org.jrebirth.af/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>org.jrebirth</groupId>
 	<artifactId>af</artifactId>
-	<version>8.0.3</version>
+	<version>8.1.0-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<name>JRebirth Application Framework</name>
@@ -64,7 +64,7 @@
 		<connection>scm:git:git://github.com/JRebirth/JRebirth.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/JRebirth/JRebirth.git</developerConnection>
 		<url>https://github.com/JRebirth/JRebirth/tree/8.x</url>
-	  <tag>jrebirth-8.0.3</tag>
+	  <tag>jrebirth-8.1.0-SNAPSHOT</tag>
   </scm>
 
 	<licenses>

--- a/org.jrebirth.af/pom.xml
+++ b/org.jrebirth.af/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>org.jrebirth</groupId>
 	<artifactId>af</artifactId>
-	<version>8.1.0-SNAPSHOT</version>
+	<version>8.0.4-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<name>JRebirth Application Framework</name>
@@ -64,7 +64,7 @@
 		<connection>scm:git:git://github.com/JRebirth/JRebirth.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/JRebirth/JRebirth.git</developerConnection>
 		<url>https://github.com/JRebirth/JRebirth/tree/8.x</url>
-	  <tag>jrebirth-8.1.0-SNAPSHOT</tag>
+	  <tag>jrebirth-8.0.4-SNAPSHOT</tag>
   </scm>
 
 	<licenses>

--- a/org.jrebirth.af/preloader/pom.xml
+++ b/org.jrebirth.af/preloader/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	

--- a/org.jrebirth.af/preloader/pom.xml
+++ b/org.jrebirth.af/preloader/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	

--- a/org.jrebirth.af/presentation/pom.xml
+++ b/org.jrebirth.af/presentation/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<groupId>org.jrebirth.af</groupId>
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/org.jrebirth.af/presentation/pom.xml
+++ b/org.jrebirth.af/presentation/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<groupId>org.jrebirth.af</groupId>
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/org.jrebirth.af/processor/pom.xml
+++ b/org.jrebirth.af/processor/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jrebirth.af</groupId>
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>modular</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.velocity</groupId>

--- a/org.jrebirth.af/processor/pom.xml
+++ b/org.jrebirth.af/processor/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jrebirth.af</groupId>
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>modular</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.velocity</groupId>

--- a/org.jrebirth.af/rest/pom.xml
+++ b/org.jrebirth.af/rest/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jrebirth</groupId>
     <artifactId>af</artifactId>
-    <version>8.1.0-SNAPSHOT</version>
+    <version>8.0.4-SNAPSHOT</version>
   </parent>
   <groupId>org.jrebirth.af</groupId>
   <artifactId>rest</artifactId>

--- a/org.jrebirth.af/rest/pom.xml
+++ b/org.jrebirth.af/rest/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jrebirth</groupId>
     <artifactId>af</artifactId>
-    <version>8.0.3</version>
+    <version>8.1.0-SNAPSHOT</version>
   </parent>
   <groupId>org.jrebirth.af</groupId>
   <artifactId>rest</artifactId>

--- a/org.jrebirth.af/sample/pom.xml
+++ b/org.jrebirth.af/sample/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -239,13 +239,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>preloader</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/org.jrebirth.af/sample/pom.xml
+++ b/org.jrebirth.af/sample/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -239,13 +239,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>preloader</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/org.jrebirth.af/security/pom.xml
+++ b/org.jrebirth.af/security/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jrebirth.af</groupId>
 	<artifactId>security</artifactId>
@@ -16,13 +16,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 			<optional>true</optional>
 		</dependency>
 		

--- a/org.jrebirth.af/security/pom.xml
+++ b/org.jrebirth.af/security/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jrebirth.af</groupId>
 	<artifactId>security</artifactId>
@@ -16,13 +16,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 			<optional>true</optional>
 		</dependency>
 		

--- a/org.jrebirth.af/showcase/analyzer/pom.xml
+++ b/org.jrebirth.af/showcase/analyzer/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>showcase</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 			<optional>true</optional>
 		</dependency>
 	</dependencies>

--- a/org.jrebirth.af/showcase/analyzer/pom.xml
+++ b/org.jrebirth.af/showcase/analyzer/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>showcase</artifactId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 			<optional>true</optional>
 		</dependency>
 	</dependencies>

--- a/org.jrebirth.af/showcase/fxml/pom.xml
+++ b/org.jrebirth.af/showcase/fxml/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>showcase</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>component</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/org.jrebirth.af/showcase/fxml/pom.xml
+++ b/org.jrebirth.af/showcase/fxml/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>showcase</artifactId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>component</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/org.jrebirth.af/showcase/pom.xml
+++ b/org.jrebirth.af/showcase/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>af</artifactId>
 		<groupId>org.jrebirth</groupId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -240,13 +240,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>preloader</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 
 	</dependencies>

--- a/org.jrebirth.af/showcase/pom.xml
+++ b/org.jrebirth.af/showcase/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>af</artifactId>
 		<groupId>org.jrebirth</groupId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -240,13 +240,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>preloader</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 
 	</dependencies>

--- a/org.jrebirth.af/showcase/undoredo/pom.xml
+++ b/org.jrebirth.af/showcase/undoredo/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>showcase</artifactId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>undoredo</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 		
 	</dependencies>

--- a/org.jrebirth.af/showcase/undoredo/pom.xml
+++ b/org.jrebirth.af/showcase/undoredo/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>showcase</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>undoredo</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 		
 	</dependencies>

--- a/org.jrebirth.af/transition/pom.xml
+++ b/org.jrebirth.af/transition/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>af</artifactId>
 		<groupId>org.jrebirth</groupId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<groupId>org.jrebirth.af</groupId>
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/org.jrebirth.af/transition/pom.xml
+++ b/org.jrebirth.af/transition/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>af</artifactId>
 		<groupId>org.jrebirth</groupId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<groupId>org.jrebirth.af</groupId>
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/org.jrebirth.af/undoredo/pom.xml
+++ b/org.jrebirth.af/undoredo/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jrebirth</groupId>
-		<version>8.0.3</version>
+		<version>8.1.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 		<artifactId>af</artifactId>
 	</parent>
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.0.3</version>
+			<version>8.1.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/org.jrebirth.af/undoredo/pom.xml
+++ b/org.jrebirth.af/undoredo/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jrebirth</groupId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 		<artifactId>af</artifactId>
 	</parent>
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>8.1.0-SNAPSHOT</version>
+			<version>8.0.4-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
This commit fix two minor bugs in WaveTypeBase. They have been reproduced and unit tested in the WaveTypeTest class.

The first one is a NoSuchElementException if you add a returnWaveType that has no items.
Now if no items have been defined the returnItem will keep its null value and ServiceTaskBase.sendReturnWave() will throw a new CoreException(NO_RETURNED_WAVE_ITEM);

The second bug happens when you define items in the returnWaveType AND in the returnItem. Action attribute will have the followings value :
```
RE_FLUSH.action() --> "DO_RE_FLUSH"
FLUSH.returnWaveType().action() --> "DO_DO_RE_FLUSH"
```
In the fix the handler method will be add in toString().

I also improve the javadoc a bit (the action method had the uuid text).
