### PR TITLE
Fix a NoSuchElementException and the method handler name construction in WaveTypeBase

### DIFF
--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/wave/WaveTypeBase.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/wave/WaveTypeBase.java
@@ -41,7 +41,8 @@ public final class WaveTypeBase implements WaveType {
     /** The unique identifier of the wave type. */
     private int uid;
 
-    /** The action to performed, basically the name of the method to call. */
+    /** The action to performed, basically the name of the method to call.
+     * The keyword "DO_" (by default see {@link JRebirthParameters.WAVE_HANDLER_PREFIX}) will be prepended to the action name to generate the handler method */
     private String action;
 
     /** Define arguments types to use. */
@@ -81,10 +82,6 @@ public final class WaveTypeBase implements WaveType {
 
     /**
      * Default constructor.
-     *
-     * @param action The action to perform, "DO_" (by default see {@link JRebirthParameters.WAVE_HANDLER_PREFIX}) keyword will be prepended to the action name to generate the handler method
-     *
-     * @param waveItems the list of #WaveItem{@link WaveItem} required by this wave
      */
     WaveTypeBase() {
 
@@ -93,9 +90,7 @@ public final class WaveTypeBase implements WaveType {
     }
 
     /**
-     * Gets the uid.
-     *
-     * @return Returns the uid.
+     * {@inheritDoc}
      */
     @Override
     public int uid() {
@@ -103,9 +98,7 @@ public final class WaveTypeBase implements WaveType {
     }
 
     /**
-     * Sets the uid.
-     *
-     * @param uid The uid to set.
+     * {@inheritDoc}
      */
     @Override
     public WaveTypeBase uid(final int uid) {
@@ -114,9 +107,7 @@ public final class WaveTypeBase implements WaveType {
     }
 
     /**
-     * Gets the action.
-     *
-     * @return Returns the action.
+     * {@inheritDoc}
      */
     @Override
     public String action() {
@@ -124,32 +115,26 @@ public final class WaveTypeBase implements WaveType {
     }
 
     /**
-     * Sets the uid.
-     *
-     * @param uid The uid to set.
+     * {@inheritDoc}
      */
     @Override
     public WaveTypeBase action(final String action) {
-
         WaveTypeRegistry.store(action, this);
-
-        // The action name will be used to define the name of the wave handler method
-        // Prepend do the the action name to force wave handler method to begin with do (convention parameterizable)
-        this.action = JRebirthParameters.WAVE_HANDLER_PREFIX.get() + action;
-
+        this.action = action;
         return this;
     }
 
     /**
-     * Gets the wave item list.
-     *
-     * @return Returns the waveItemList.
+     * {@inheritDoc}
      */
     @Override
     public List<WaveItem<?>> items() {
         return this.waveItemList;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public WaveTypeBase items(final WaveItem<?>... items) {
         // Add each wave item to manage method argument
@@ -160,9 +145,7 @@ public final class WaveTypeBase implements WaveType {
     }
 
     /**
-     * Gets the action.
-     *
-     * @return Returns the action.
+     * {@inheritDoc}
      */
     @Override
     public String returnAction() {
@@ -170,9 +153,7 @@ public final class WaveTypeBase implements WaveType {
     }
 
     /**
-     * Sets the uid.
-     *
-     * @param uid The uid to set.
+     * {@inheritDoc}
      */
     @Override
     public WaveTypeBase returnAction(final String returnAction) {
@@ -220,7 +201,7 @@ public final class WaveTypeBase implements WaveType {
     public WaveType returnWaveType(final WaveType returnWaveType) {
         this.returnWaveType = returnWaveType;
         this.returnAction = returnWaveType.action();
-        this.returnItem = returnWaveType.items().stream().findFirst().get();
+        this.returnItem = returnWaveType.items().stream().findFirst().orElse(null);
         return this;
     }
 
@@ -275,7 +256,9 @@ public final class WaveTypeBase implements WaveType {
      */
     @Override
     public String toString() {
-        return this.action;
+        // The action name will be used to define the name of the wave handler method
+        // Prepend do before the action name to force wave handler method to begin with do (convention parameterizable)
+        return JRebirthParameters.WAVE_HANDLER_PREFIX.get() + this.action;
     }
 
     /**

--- a/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/wave/WaveTypeTest.java
+++ b/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/wave/WaveTypeTest.java
@@ -1,0 +1,52 @@
+/**
+ * Get more info at : www.jrebirth.org .
+ * Copyright JRebirth.org © 2011-2015
+ * Contact : sebastien.bordes@jrebirth.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jrebirth.af.core.wave;
+
+import junit.framework.Assert;
+import org.jrebirth.af.api.wave.contract.WaveItem;
+import org.jrebirth.af.api.wave.contract.WaveType;
+import org.junit.Test;
+
+
+public class WaveTypeTest {
+
+    @Test
+    public void testTheReturnItemOfReturnWaveType() {
+        WaveType RE_FLUSH = Builders.waveType("RE_FLUSH");
+        WaveType FLUSH = Builders.waveType("FLUSH").returnWaveType(RE_FLUSH);
+
+        Assert.assertTrue(FLUSH.returnWaveType().items().isEmpty());
+        Assert.assertNull(FLUSH.returnItem());
+    }
+
+    @Test
+    public void testHandlerMethodName() {
+        WaveItem RESULT = new WaveItemBase<Object>() {};
+        WaveType RE_FLUSH = Builders.waveType("RE_FLUSH").items(RESULT);
+        WaveType FLUSH = Builders.waveType("FLUSH").returnWaveType(RE_FLUSH).returnItem(RESULT);
+
+        Assert.assertEquals("FLUSH", FLUSH.action());
+        Assert.assertEquals("DO_FLUSH", FLUSH.toString());
+
+        Assert.assertEquals("RE_FLUSH", RE_FLUSH.action());
+        Assert.assertEquals("DO_RE_FLUSH", RE_FLUSH.toString());
+
+        Assert.assertEquals("RE_FLUSH", FLUSH.returnWaveType().action());
+        Assert.assertEquals("DO_RE_FLUSH", FLUSH.returnWaveType().toString());
+    }
+}


### PR DESCRIPTION
This commit fix two minor bugs in WaveTypeBase. They have been reproduced and unit tested in the WaveTypeTest class.

The first one is a NoSuchElementException if you add a returnWaveType that has no items.
Now if no items have been defined the returnItem will keep its null value and ServiceTaskBase.sendReturnWave() will throw a new CoreException(NO_RETURNED_WAVE_ITEM);

The second bug happens when you define items in the returnWaveType AND in the returnItem. Action attribute will have the followings value :
```
RE_FLUSH.action() --> "DO_RE_FLUSH"
FLUSH.returnWaveType().action() --> "DO_DO_RE_FLUSH" <-- Error here
```
In the fix the handler method will be add in toString().

I also improve the javadoc a bit (the action method had the uuid text).