### PR TITLE
Resources could be garbage collected before getting it in resource builder

### DIFF
--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/resource/builder/AbstractResourceBuilder.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/resource/builder/AbstractResourceBuilder.java
@@ -87,20 +87,18 @@ public abstract class AbstractResourceBuilder<I extends ResourceItem<?, ?, ?>, P
 
         final String paramsKey = params.getKey();
 
-        // Retrieve the resource into the map
-        WeakReference<R> resource = this.resourceMap.get(paramsKey);
+        // Retrieve the resource weak reference from the map
+        WeakReference<R> resourceWeakRef = this.resourceMap.get(paramsKey);
 
-        // The resource may be null if nobody use it
-        if (resource == null || resource.get() == null) {
+        // The resourceWeakRef may be null if nobody use it
+        R resource = resourceWeakRef == null ? null : resourceWeakRef.get();
+        if (resourceWeakRef == null || resource == null) {
             // So we must rebuild an instance and then store it weakly
-            set(paramsKey, buildResource(key, params));
-
-            // Get the WeakReference
-            resource = this.resourceMap.get(paramsKey);
-
+            resource = buildResource(key, params);
+            set(paramsKey, resource);
             params.hasChanged(false);
         }
-        return resource.get();
+        return resource;
     }
 
     /**


### PR DESCRIPTION
Hi Seb' !

A small bug fix when calling get() on a resource.
It was actually possible to receive null value if the garbage collector wanted to say us "a little hello" between the resource construction and the return of the method. I fix it by adding a strong reference in the method.

I was also wondering about using SoftReference instead of WeakReference here to keep resources longer in cache and build them less often. But I do not know if it's better to keep objects longer in memory in terms of performance.
