### PR TITLE
Add preStop and postStop methods to perform custom task when exiting app

### DIFF
--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/application/AbstractApplication.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/application/AbstractApplication.java
@@ -291,6 +291,7 @@ public abstract class AbstractApplication<P extends Pane> extends Application im
     public final void stop() throws CoreException {
         try {
             LOGGER.log(STOP_APPLICATION, this.getClass().getSimpleName());
+            preStop();
             super.stop();
 
             // Hide the stage is this method wasn't call by user
@@ -318,6 +319,7 @@ public abstract class AbstractApplication<P extends Pane> extends Application im
                 }
             } while (JRebirthThread.getThread().isAlive());
 
+            postStop();
             LOGGER.log(STOPPED_SUCCESSFULLY, this.getClass().getSimpleName());
 
         } catch (final Exception e) { // NOSONAR Catch all exception during stopping phase
@@ -325,6 +327,18 @@ public abstract class AbstractApplication<P extends Pane> extends Application im
             throw new CoreException(e);
         }
     }
+
+    /**
+     * Perform custom task before application stop phase.
+     */
+    protected abstract void preStop();
+
+    /**
+     * Perform custom task after application stop.
+     * Careful: this method if called after JRebirth shutdown process. So you must not effectuate things that would be
+     * used JRebirth action here (like sending a wave, get a service...)
+     */
+    protected abstract void postStop();
 
     /**
      * Customize the primary Stage.

--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/application/DefaultApplication.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/application/DefaultApplication.java
@@ -1,16 +1,15 @@
 package org.jrebirth.af.core.application;
 
-import java.util.Collections;
-import java.util.List;
-
 import javafx.scene.Scene;
 import javafx.scene.layout.Pane;
 import javafx.stage.Stage;
-
 import org.jrebirth.af.api.exception.CoreRuntimeException;
 import org.jrebirth.af.api.resource.ResourceItem;
 import org.jrebirth.af.api.ui.Model;
 import org.jrebirth.af.api.wave.Wave;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  *
@@ -37,6 +36,22 @@ public class DefaultApplication<P extends Pane> extends AbstractApplication<P> {
      */
     @Override
     protected void postInit() {
+        // Nothing to do yet
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void preStop() {
+        // Nothing to do yet
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void postStop() {
         // Nothing to do yet
     }
 


### PR DESCRIPTION
I added two conveniants methods in AbstractApplication : preStop and postStop.
As their names indicates, these methods are called before and after the JRebirth stop process (where JIT is closed).
