### PR TITLE
Add moduleStarterClass property to jrebirth.properties

### DIFF
--- a/org.jrebirth.af/archetype/src/main/resources/archetype-resources/src/main/resources/jrebirth.properties
+++ b/org.jrebirth.af/archetype/src/main/resources/archetype-resources/src/main/resources/jrebirth.properties
@@ -33,6 +33,8 @@ closeRetryDelayOther=1000
 threadPoolSizeRatio=2
 ## This parameter is used to add a prefix to custom wave handler method of JRebirth components. They will be named like this : doMyAction(Wave) after being renamed in camel case.
 waveHandlerPrefix=DO_
+## Module starter class
+moduleStarterClass=${package}.SampleModuleStarter
 ##
 ###################################################################################################
 ###								Application Resource Parameters									###

--- a/org.jrebirth.af/showcase/demo/pom.xml
+++ b/org.jrebirth.af/showcase/demo/pom.xml
@@ -174,7 +174,7 @@
 			<plugin>
 				<groupId>com.akathist.maven.plugins.launch4j</groupId>
 				<artifactId>launch4j-maven-plugin</artifactId>
-				<version>1.5.1</version>
+				<version>1.7.10</version>
 				<executions>
 					<execution>
 						<id>l4j-clui</id>


### PR DESCRIPTION
Add a new property to specify custom module starter name.
This resolves issue #199.

Now if `moduleStarterClass` property is specified we use this value to create the module starter when compiling, otherwise use maven's pom.xml file as before.
