### PR TITLE
ChainWaveCommand status become handled before all chain waves have terminated

### DIFF
--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/command/basic/ChainWaveCommand.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/command/basic/ChainWaveCommand.java
@@ -57,8 +57,6 @@ public class ChainWaveCommand extends DefaultCommand implements WaveListener {
 
             this.waveList = wave.get(JRebirthWaves.CHAINED_WAVES);
             this.sourceWave = wave;
-
-            fireHandled(this.sourceWave);
         }
 
         unqueueWaves();
@@ -87,6 +85,8 @@ public class ChainWaveCommand extends DefaultCommand implements WaveListener {
             // Run next command if any
             if (this.waveList.size() > this.index) {
                 unqueueWaves();
+            } else {
+                fireHandled(this.sourceWave);
             }
         } else {
 


### PR DESCRIPTION
Hi Seb',

Everything is in the title. Handle status should be fired only in the waveHandled() method or any other place where we are sure all waves have been executed.

I had some difficulties to add a single-simple-proper unit test so if you have the possibility to add one it would be welcomed.