### PR TITLE
Set the wave status to fail if any error occured in a command

### DIFF
--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/command/CommandRunnable.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/command/CommandRunnable.java
@@ -66,9 +66,9 @@ final class CommandRunnable extends AbstractJrbRunnable {
         try {
             // Call the innerRun available with package visibility
             this.command.innerRun(this.wave);
-        } catch (final CommandException ce) {
+        } catch (final Exception e) {
             // Log any error occurred during the execution of this command
-            LOGGER.error("Command has failed :", ce);
+            LOGGER.error("Command has failed :", e);
             // Then update the wave status in order to perform right task after this failure
             this.wave.status(Wave.Status.Failed);
         }


### PR DESCRIPTION
Hi Seb!

Here is a pull request to improve error management when a command fail.

If any exception occured in a command (such a NPE), the exception was never catched. So the wave status was never changed to fail and the command just stopped. Attached listeners were never informed of this problem.