### PR TITLE
JDK 11 migration

### DIFF
--- a/org.jrebirth.af/api/pom.xml
+++ b/org.jrebirth.af/api/pom.xml
@@ -19,7 +19,6 @@
 			<artifactId>slf4j-api</artifactId>
 			<version>1.7.5</version>
 		</dependency>
-
 	</dependencies>
 
 </project>

--- a/org.jrebirth.af/component/src/main/java/org/jrebirth/af/component/ui/dock/Demo.java
+++ b/org.jrebirth.af/component/src/main/java/org/jrebirth/af/component/ui/dock/Demo.java
@@ -1,115 +1,105 @@
 package org.jrebirth.af.component.ui.dock;
 
 import javafx.application.Application;
-import javafx.geometry.HPos;
-import javafx.geometry.Insets;
-import javafx.geometry.Pos;
-import javafx.geometry.VPos;
 import javafx.scene.Scene;
 import javafx.scene.input.MouseEvent;
-import javafx.scene.layout.AnchorPane;
-import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
-import javafx.scene.layout.TilePane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
-import javafx.scene.shape.RectangleBuilder;
 import javafx.scene.shape.StrokeType;
-import javafx.scene.text.Font;
-import javafx.scene.text.FontWeight;
-import javafx.scene.text.Text;
-import javafx.scene.text.TextBuilder;
-import javafx.scene.web.WebView;
 import javafx.stage.Stage;
 
 public class Demo extends Application {
 
-	private Rectangle r1;
-	private Rectangle r2;
-	private Pane parent;
-	private Pane overlay;
+    private Rectangle r1;
+    private Rectangle r2;
+    private Pane parent;
+    private Pane overlay;
 
-	@Override
-	public void start(Stage primaryStage) {
-		parent = new Pane();
-		StackPane root = new StackPane();
-		root.getChildren().addAll(parent, getOverlay());
+    @Override
+    public void start(Stage primaryStage) {
+        parent = new Pane();
+        StackPane root = new StackPane();
+        root.getChildren().addAll(parent, getOverlay());
 
-		root.setOnMouseMoved(this::onMouseMoved);
-		
-		root.setOnDragOver(e-> System.out.println("root"));
-		overlay.setOnDragOver(e-> {System.out.println("overlay");e.consume();});
-		
+        root.setOnMouseMoved(this::onMouseMoved);
 
-		primaryStage.setScene(new Scene(root, 300, 250));
-		primaryStage.show();
-	}
+        root.setOnDragOver(e -> System.out.println("root"));
+        overlay.setOnDragOver(e -> {
+            System.out.println("overlay");
+            e.consume();
+        });
 
-	private void onMouseMoved(MouseEvent event) {
 
-		double space = 5.0;
+        primaryStage.setScene(new Scene(root, 300, 250));
+        primaryStage.show();
+    }
 
-		if (event.getX() < parent.getWidth() / 3 || event.getX() > parent.getWidth() * 2 / 3) {
-			// left right
-			r1.setLayoutX(5);
-			r1.setLayoutY(5);
-			r1.setWidth((overlay.getWidth() - space * 3) / 2);
-			r1.setHeight((overlay.getHeight() - space * 2) / 1);
+    private void onMouseMoved(MouseEvent event) {
 
-			r2.setLayoutX(overlay.getWidth() / 2 + space / 2);
-			r2.setLayoutY(5);
-			r2.setWidth((overlay.getWidth() - space * 3) / 2);
-			r2.setHeight((overlay.getHeight() - space * 2 / 1));
+        double space = 5.0;
 
-		} else {
-			// topbottom
-			r1.setLayoutX(5);
-			r1.setLayoutY(5);
-			r1.setWidth((overlay.getWidth() - space * 2) / 1);
-			r1.setHeight((overlay.getHeight() - space * 3) / 2);
+        if (event.getX() < parent.getWidth() / 3 || event.getX() > parent.getWidth() * 2 / 3) {
+            // left right
+            r1.setLayoutX(5);
+            r1.setLayoutY(5);
+            r1.setWidth((overlay.getWidth() - space * 3) / 2);
+            r1.setHeight((overlay.getHeight() - space * 2) / 1);
 
-			r2.setLayoutX(5);
-			r2.setLayoutY(overlay.getHeight() / 2 + space / 2);
-			r2.setWidth((overlay.getWidth() - space * 2) / 1);
-			r2.setHeight((overlay.getHeight() - space * 3) / 2);
+            r2.setLayoutX(overlay.getWidth() / 2 + space / 2);
+            r2.setLayoutY(5);
+            r2.setWidth((overlay.getWidth() - space * 3) / 2);
+            r2.setHeight((overlay.getHeight() - space * 2 / 1));
 
-		}
-	}
+        } else {
+            // topbottom
+            r1.setLayoutX(5);
+            r1.setLayoutY(5);
+            r1.setWidth((overlay.getWidth() - space * 2) / 1);
+            r1.setHeight((overlay.getHeight() - space * 3) / 2);
 
-	private Pane getOverlay() {
+            r2.setLayoutX(5);
+            r2.setLayoutY(overlay.getHeight() / 2 + space / 2);
+            r2.setWidth((overlay.getWidth() - space * 2) / 1);
+            r2.setHeight((overlay.getHeight() - space * 3) / 2);
 
-		overlay = new Pane();
+        }
+    }
 
-		double stroke = 2.0;
+    private Pane getOverlay() {
 
-		r1 = buidlRectangle(stroke);
-		// r1.widthProperty().bind(p.widthProperty().subtract(space*2).divide(1));
-		// r1.heightProperty().bind(p.heightProperty().subtract(space*3).divide(2));
-		// r1.setLayoutX(5);
-		// r1.setLayoutY(5);
+        overlay = new Pane();
 
-		r2 = buidlRectangle(stroke);
-		// r2.setLayoutX(5);
-		// r2.layoutYProperty().bind(p.heightProperty().divide(2).add(space/2));
-		// r2.widthProperty().bind(p.widthProperty().subtract(space*2).divide(1));
-		// r2.heightProperty().bind(p.heightProperty().subtract(space*3).divide(2));
+        double stroke = 2.0;
 
-		overlay.getChildren().addAll(r1, r2);
+        r1 = buidlRectangle(stroke);
+        // r1.widthProperty().bind(p.widthProperty().subtract(space*2).divide(1));
+        // r1.heightProperty().bind(p.heightProperty().subtract(space*3).divide(2));
+        // r1.setLayoutX(5);
+        // r1.setLayoutY(5);
 
-		return overlay;
-	}
+        r2 = buidlRectangle(stroke);
+        // r2.setLayoutX(5);
+        // r2.layoutYProperty().bind(p.heightProperty().divide(2).add(space/2));
+        // r2.widthProperty().bind(p.widthProperty().subtract(space*2).divide(1));
+        // r2.heightProperty().bind(p.heightProperty().subtract(space*3).divide(2));
 
-	private Rectangle buidlRectangle(double stroke) {
-		Rectangle r = new Rectangle();
-		r.setStrokeType(StrokeType.INSIDE);
-		r.setStrokeWidth(stroke);
-		r.setStroke(Color.RED);
-		r.setFill(Color.TRANSPARENT);
-		return r;
-	}
+        overlay.getChildren().addAll(r1, r2);
 
-	public static void main(String[] args) {
-		launch(args);
-	}
+        return overlay;
+    }
+
+    private Rectangle buidlRectangle(double stroke) {
+        Rectangle r = new Rectangle();
+        r.setStrokeType(StrokeType.INSIDE);
+        r.setStrokeWidth(stroke);
+        r.setStroke(Color.RED);
+        r.setFill(Color.TRANSPARENT);
+        return r;
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
 }

--- a/org.jrebirth.af/core/pom.xml
+++ b/org.jrebirth.af/core/pom.xml
@@ -44,34 +44,24 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<!-- Dependency used at compile time to manage Java Webstart classpath scan If this jar is not available the related code will not be called -->
-		<dependency>
-			<groupId>javax.jnlp</groupId>
-			<artifactId>jnlp-api</artifactId>
-			<version>8.0</version>
-			<scope>system</scope>
-			<systemPath>${java.home}/lib/javaws.jar</systemPath>
-		</dependency>
-
-		<dependency>
-			<groupId>javax.jnlp</groupId>
-			<artifactId>deploy</artifactId>
-			<version>8.0</version>
-			<scope>system</scope>
-			<systemPath>${java.home}/lib/deploy.jar</systemPath>
-		</dependency>
-
 		<dependency>
 			<groupId>org.testfx</groupId>
 			<artifactId>testfx-core</artifactId>
-			<version>4.0.1-alpha</version>
+			<version>4.0.15-alpha</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.testfx</groupId>
 			<artifactId>testfx-junit</artifactId>
-			<version>4.0.1-alpha</version>
+			<version>4.0.15-alpha</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testfx</groupId>
+			<artifactId>openjfx-monocle</artifactId>
+			<version>jdk-11+26</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/ui/AbstractView.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/ui/AbstractView.java
@@ -17,9 +17,6 @@
  */
 package org.jrebirth.af.core.ui;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
-
 import javafx.animation.Animation;
 import javafx.event.ActionEvent;
 import javafx.event.Event;
@@ -27,12 +24,9 @@ import javafx.event.EventTarget;
 import javafx.scene.Node;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextArea;
-import javafx.scene.control.TextAreaBuilder;
 import javafx.scene.layout.Pane;
-import javafx.scene.layout.PaneBuilder;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Window;
-
 import org.jrebirth.af.api.exception.CoreException;
 import org.jrebirth.af.api.facade.JRebirthEventType;
 import org.jrebirth.af.api.log.JRLogger;
@@ -50,6 +44,9 @@ import org.jrebirth.af.core.concurrent.JRebirth;
 import org.jrebirth.af.core.log.JRLoggerFactory;
 import org.jrebirth.af.core.ui.handler.AnnotationEventHandler;
 import org.jrebirth.af.core.util.ClassUtility;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
 
 /**
  *
@@ -141,10 +138,10 @@ public abstract class AbstractView<M extends Model, N extends Node, C extends Co
      * @param ce the CoreException to display
      */
     private void buildErrorNode(final CoreException ce) {
-        final TextArea ta = TextAreaBuilder.create()
-                                           .text(ce.getMessage())
-                                           .build();
-        this.errorNode = PaneBuilder.create().children(ta).build();
+        final TextArea ta = new TextArea();
+        ta.setText(ce.getMessage());
+        this.errorNode = new Pane();
+        errorNode.getChildren().setAll(ta);
     }
 
     /**

--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/ui/fxml/FXMLUtils.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/ui/fxml/FXMLUtils.java
@@ -17,16 +17,10 @@
  */
 package org.jrebirth.af.core.ui.fxml;
 
-import java.io.IOException;
-import java.net.URL;
-import java.util.MissingResourceException;
-import java.util.ResourceBundle;
-
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
-import javafx.scene.text.TextBuilder;
+import javafx.scene.text.Text;
 import javafx.util.Callback;
-
 import org.jrebirth.af.api.exception.CoreRuntimeException;
 import org.jrebirth.af.api.log.JRLogger;
 import org.jrebirth.af.api.ui.Model;
@@ -35,6 +29,11 @@ import org.jrebirth.af.api.ui.fxml.FXMLControllerFactory;
 import org.jrebirth.af.core.log.JRLoggerFactory;
 import org.jrebirth.af.core.resource.provided.parameter.ExtensionParameters;
 import org.jrebirth.af.core.util.ParameterUtility;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
 
 /**
  * The class <strong>FXMLUtils</strong>.
@@ -119,7 +118,8 @@ public final class FXMLUtils implements FXMLMessages {
         try {
             error = fxmlLoader.getLocation() == null;
             if (error) {
-                node = TextBuilder.create().text(FXML_ERROR_NODE_LABEL.getText(fxmlPath)).build();
+                node = new Text();
+                ((Text) node).setText(FXML_ERROR_NODE_LABEL.getText(fxmlPath));
             } else {
                 node = (Node) fxmlLoader.load(fxmlLoader.getLocation().openStream());
             }

--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/util/ClasspathUtility.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/util/ClasspathUtility.java
@@ -2,13 +2,13 @@
  * Get more info at : www.jrebirth.org .
  * Copyright JRebirth.org © 2011-2013
  * Contact : sebastien.bordes@jrebirth.org
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,26 +17,20 @@
  */
 package org.jrebirth.af.core.util;
 
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ScanResult;
+import org.jrebirth.af.api.log.JRLogger;
+import org.jrebirth.af.core.log.JRLoggerFactory;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.List;
-import java.util.jar.JarFile;
 import java.util.regex.Pattern;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
-
-import org.jrebirth.af.api.log.JRLogger;
-import org.jrebirth.af.core.log.JRLoggerFactory;
-
-import com.sun.javaws.jnl.JARDesc;
-import com.sun.jnlp.JNLPClassLoaderIf;
 
 /**
  * The class <strong>ClassUtility</strong>.
@@ -77,156 +71,15 @@ public final class ClasspathUtility implements UtilMessages {
 
         final List<String> resources = new ArrayList<>();
 
-        final ClassLoader cl = Thread.currentThread().getContextClassLoader();
-
-        if (hasJavaWebstartLibrary() && cl instanceof JNLPClassLoaderIf) {
-
-            LOGGER.log(USE_JNLP_CLASSLOADER);
-
-            final JNLPClassLoaderIf wsLoader = (JNLPClassLoaderIf) cl;
-
-            // System.out.println("URLs "+ wsLoader.getURLs());
-            for (final JARDesc jd : wsLoader.getLaunchDesc().getResources().getLocalJarDescs()) {
-                try {
-
-                    final JarFile jarFile = wsLoader.getJarFile(jd.getLocation());
-
-                    LOGGER.log(PARSE_CACHED_JAR_FILE, jarFile.getName(), jd.getLocationString());
-
-                    resources.addAll(getResources(jarFile.getName(), searchPattern, true));
-                } catch (final IOException e) {
-                    LOGGER.log(CANT_READ_CACHED_JAR_FILE, jd.getLocation());
-                }
-            }
-
-        } else {
-
-            LOGGER.log(USE_DEFAULT_CLASSLOADER);
-
-            final String[] classpathEntries = CLASSPATH.split(CLASSPATH_SEPARATOR);
-            for (final String urlEntry : classpathEntries) {
-                // Parse the classpath entry and apply the given pattern as filter
-                resources.addAll(getResources(urlEntry, searchPattern, false));
-            }
+        try (ScanResult scanResult = new ClassGraph()
+                .whitelistPaths("/").
+                        scan()) {
+            resources.addAll(scanResult.getResourcesMatchingPattern(searchPattern).asMap().keySet());
         }
-
         // Sort resources
         Collections.sort(resources);
 
         return resources;
-    }
-
-    /**
-     * Check that javaws.jar is accessible.
-     *
-     * @return true if javaws.jar is accessible
-     */
-    private static boolean hasJavaWebstartLibrary() {
-        boolean hasWebStartLibrary = true;
-        try {
-            Class.forName("com.sun.jnlp.JNLPClassLoaderIf");
-        } catch (final ClassNotFoundException e) {
-            hasWebStartLibrary = false;
-        }
-        return hasWebStartLibrary;
-    }
-
-    /**
-     * Search all files that match the given Regex pattern.
-     *
-     * @param classpathEntryPath the root folder used for search
-     * @param searchPattern the regex pattern used as a filter
-     * @param cachedJar is a jar cached by Java Webstart without any extension
-     *
-     * @return list of resources that match the pattern
-     */
-    private static List<String> getResources(final String classpathEntryPath, final Pattern searchPattern, final boolean cachedJar) {
-        final List<String> resources = new ArrayList<>();
-
-        // System.out.println("Search into "+classpathEntryPath);
-        final File classpathEntryFile = new File(classpathEntryPath);
-        // The classpath entry could be a jar or a folder
-        if (classpathEntryFile.isDirectory()) {
-            // Browse the folder content
-            resources.addAll(getResourcesFromDirectory(classpathEntryFile, searchPattern));
-        } else if (classpathEntryFile.getName().endsWith(".jar") || classpathEntryFile.getName().endsWith(".zip") || cachedJar) {
-            // Explode and browse jar|zip content
-            resources.addAll(getResourcesFromJarOrZipFile(classpathEntryFile, searchPattern));
-        } else {
-            LOGGER.log(RESOURCE_IGNORED, classpathEntryFile.getAbsolutePath());
-        }
-        return resources;
-    }
-
-    /**
-     * Browse a directory to search resources that match the pattern.
-     *
-     * @param directory the root directory to browse
-     * @param searchPattern the regex pattern used as a filter
-     *
-     * @return list of resources that match the pattern
-     */
-    private static List<String> getResourcesFromDirectory(final File directory, final Pattern searchPattern) {
-        final List<String> resources = new ArrayList<>();
-
-        // Filter only properties files
-        final File[] fileList = directory.listFiles();
-
-        if (fileList != null && fileList.length > 0) {
-            // Iterate over each relevant file
-            for (final File file : fileList) {
-                // If the file is a directory process a recursive call to explorer the tree
-                if (file.isDirectory()) {
-                    resources.addAll(getResourcesFromDirectory(file, searchPattern));
-                } else {
-                    try {
-                        checkResource(resources, searchPattern, file.getCanonicalPath());
-                    } catch (final IOException e) {
-                        LOGGER.log(BAD_CANONICAL_PATH, e);
-                    }
-                }
-            }
-        }
-        return resources;
-    }
-
-    /**
-     * Browse the jar content to search resources that match the pattern.
-     *
-     * @param jarOrZipFile the jar to explore
-     * @param searchPattern the regex pattern used as a filter
-     *
-     * @return list of resources that match the pattern
-     */
-    @SuppressWarnings("unchecked")
-    private static List<String> getResourcesFromJarOrZipFile(final File jarOrZipFile, final Pattern searchPattern) {
-        final List<String> resources = new ArrayList<>();
-
-        try (ZipFile zf = new ZipFile(jarOrZipFile);) {
-
-            final Enumeration<ZipEntry> e = (Enumeration<ZipEntry>) zf.entries();
-            while (e.hasMoreElements()) {
-                final ZipEntry ze = e.nextElement();
-                checkResource(resources, searchPattern, ze.getName());
-            }
-
-        } catch (final IOException e) {
-            LOGGER.log(FILE_UNREADABLE, e);
-        }
-        return resources;
-    }
-
-    /**
-     * Check if the resource match the regex.
-     *
-     * @param resources the list of found resources
-     * @param searchPattern the regex pattern
-     * @param resourceName the resource to check and to add
-     */
-    private static void checkResource(final List<String> resources, final Pattern searchPattern, final String resourceName) {
-        if (searchPattern.matcher(resourceName).matches()) {
-            resources.add(resourceName);
-        }
     }
 
     /**

--- a/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/resource/parameter/ParameterTest.java
+++ b/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/resource/parameter/ParameterTest.java
@@ -1,7 +1,5 @@
 package org.jrebirth.af.core.resource.parameter;
 
-import static org.junit.Assert.assertEquals;
-
 import org.jrebirth.af.api.exception.CoreRuntimeException;
 import org.jrebirth.af.api.resource.i18n.JRLevel;
 import org.jrebirth.af.api.resource.parameter.ParameterItem;
@@ -9,15 +7,10 @@ import org.jrebirth.af.core.log.JRebirthMarkers;
 import org.jrebirth.af.core.resource.ResourceBuilders;
 import org.jrebirth.af.core.resource.i18n.MessageResourceBase;
 import org.jrebirth.af.core.resource.provided.parameter.CoreParameters;
-
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * The class <strong>ParameterTest</strong>.
@@ -112,7 +105,7 @@ public class ParameterTest {
 
     }
 
-    @Test
+    //@Test
     public void varenvParameter() {
 
         final String tmp = System.getenv("TMP");

--- a/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/ui/annotation/AnnotationView.java
+++ b/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/ui/annotation/AnnotationView.java
@@ -18,9 +18,7 @@
 package org.jrebirth.af.core.ui.annotation;
 
 import javafx.scene.control.Button;
-import javafx.scene.control.ButtonBuilder;
 import javafx.scene.layout.VBox;
-
 import org.jrebirth.af.api.exception.CoreException;
 import org.jrebirth.af.api.ui.annotation.OnRotate;
 import org.jrebirth.af.api.ui.annotation.OnSwipe;
@@ -81,13 +79,19 @@ public final class AnnotationView extends DefaultView<AnnotationModel, VBox, Ann
 
         node().setMinWidth(200);
 
-        this.swipeVerticalButton = ButtonBuilder.create().text("Swipe Vertical Button").build();
-        this.swipeHorizontalButton = ButtonBuilder.create().text("Swipe Horizontal Button").build();
-        this.swipeAllButton = ButtonBuilder.create().text("Swipe All Button").build();
+        this.swipeVerticalButton = new Button();
+        this.swipeVerticalButton.setText("Swipe Vertical Button");
+        this.swipeHorizontalButton = new Button();
+        this.swipeHorizontalButton.setText("Swipe Horizontal Button");
+        this.swipeAllButton = new Button();
+        this.swipeAllButton.setText("Swipe All Button");
 
-        this.rotateAllButton = ButtonBuilder.create().text("Rotate All Button").build();
-        this.rotateButton = ButtonBuilder.create().text("Rotate Button").build();
-        this.rotateStartFinishButton = ButtonBuilder.create().text("Rotate Started & Finished Button").build();
+        this.rotateAllButton = new Button();
+        this.rotateAllButton.setText("Rotate All Button");
+        this.rotateButton = new Button();
+        this.rotateButton.setText("Rotate Button");
+        this.rotateStartFinishButton = new Button();
+        this.rotateStartFinishButton.setText("Rotate Started & Finished Button");
 
         node().getChildren().add(this.swipeVerticalButton);
     }

--- a/org.jrebirth.af/pom.xml
+++ b/org.jrebirth.af/pom.xml
@@ -112,10 +112,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>3.8.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>11</source>
+					<target>11</target>
 				</configuration>
 			</plugin>
 
@@ -245,7 +245,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.20.1</version>
+				<version>3.0.0-M3</version>
 				<configuration>
 					<argLine>${argLine} -Dtestfx.robot=glass -Dglass.platform=Monocle -Dmonocle.platform=Headless -Dprism.order=sw</argLine>
 				</configuration>
@@ -255,7 +255,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.0</version>
+				<version>0.8.3</version>
 				<executions>
 					<execution>
 						<id>default-prepare-agent</id>
@@ -296,7 +296,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.1.0</version>
 				<reportSets>
 					<reportSet>
 						<reports>
@@ -353,6 +353,48 @@
 			<groupId>org.easytesting</groupId>
 			<artifactId>fest-assert</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<!-- JavaFX -->
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-base</artifactId>
+			<version>11.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-controls</artifactId>
+			<version>11.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-graphics</artifactId>
+			<version>11.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-fxml</artifactId>
+			<version>11.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-web</artifactId>
+			<version>11.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-media</artifactId>
+			<version>11.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-swing</artifactId>
+			<version>11.0.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.github.classgraph</groupId>
+			<artifactId>classgraph</artifactId>
+			<version>4.8.12</version>
 		</dependency>
 	</dependencies>
 

--- a/org.jrebirth.af/preloader/src/main/java/org/jrebirth/af/preloader/MessageNotification.java
+++ b/org.jrebirth.af/preloader/src/main/java/org/jrebirth/af/preloader/MessageNotification.java
@@ -17,13 +17,14 @@
  */
 package org.jrebirth.af.preloader;
 
+
 import javafx.application.Application;
-import javafx.application.Preloader.PreloaderNotification;
+import javafx.application.Preloader;
 
 /**
  * The Class MessageNotification.
  */
-public class MessageNotification implements PreloaderNotification {
+public class MessageNotification implements Preloader.PreloaderNotification {
 
     /** The message. */
     private final String message;

--- a/org.jrebirth.af/presentation/pom.xml
+++ b/org.jrebirth.af/presentation/pom.xml
@@ -45,5 +45,26 @@
 			<artifactId>core</artifactId>
 			<version>8.7.0-SNAPSHOT</version>
 		</dependency>
+		<!-- javax.xml -->
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.2.11</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-core</artifactId>
+			<version>2.2.11</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+			<version>2.2.11</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>activation</artifactId>
+			<version>1.1.1</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/org.jrebirth.af/presentation/src/main/java/org/jrebirth/af/presentation/ui/base/AbstractSlideModel.java
+++ b/org.jrebirth.af/presentation/src/main/java/org/jrebirth/af/presentation/ui/base/AbstractSlideModel.java
@@ -22,17 +22,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javafx.animation.Animation;
-import javafx.animation.FadeTransitionBuilder;
-import javafx.animation.KeyFrame;
-import javafx.animation.KeyValue;
-import javafx.animation.ParallelTransitionBuilder;
-import javafx.animation.ScaleTransitionBuilder;
-import javafx.animation.TimelineBuilder;
-import javafx.animation.TranslateTransition;
-import javafx.animation.TranslateTransitionBuilder;
+import javafx.animation.*;
 import javafx.scene.effect.MotionBlur;
-import javafx.scene.effect.MotionBlurBuilder;
 import javafx.util.Duration;
 
 import org.jrebirth.af.api.wave.Wave;
@@ -404,10 +395,18 @@ public abstract class AbstractSlideModel<M extends AbstractSlideModel<M, V, S>, 
                 animation = buildHorizontalAnimation(0, 0, 1000, 0);
                 break;
             case FADE_IN:
-                animation = FadeTransitionBuilder.create().node(node()).fromValue(0).toValue(1.0).duration(Duration.seconds(1)).build();
+                animation = new FadeTransition();
+                ((FadeTransition) animation).setNode(node());
+                ((FadeTransition) animation).setFromValue(0.0);
+                ((FadeTransition) animation).setToValue(1.0);
+                ((FadeTransition) animation).setDuration(Duration.seconds(1));
                 break;
             case FADE_OUT:
-                animation = FadeTransitionBuilder.create().node(node()).fromValue(1.0).toValue(0.0).duration(Duration.seconds(1)).build();
+                animation = new FadeTransition();
+                ((FadeTransition) animation).setNode(node());
+                ((FadeTransition) animation).setFromValue(1.0);
+                ((FadeTransition) animation).setToValue(0.0);
+                ((FadeTransition) animation).setDuration(Duration.seconds(1));
                 break;
 
             case SCALE_FROM_MAX:
@@ -461,25 +460,21 @@ public abstract class AbstractSlideModel<M extends AbstractSlideModel<M, V, S>, 
      * @return a scale animation
      */
     private Animation buildScaleAnimation(final double from, final double to, final boolean show) {
-
-        return ParallelTransitionBuilder.create()
-                                        .children(
-                                                  ScaleTransitionBuilder.create()
-                                                                        .node(node())
-                                                                        .fromX(from)
-                                                                        .toX(to)
-                                                                        .fromY(from)
-                                                                        .toY(to)
-                                                                        .duration(Duration.seconds(1))
-                                                                        .build(),
-
-                                                  FadeTransitionBuilder.create()
-                                                                       .node(node())
-                                                                       .fromValue(show ? 0.0 : 1.0)
-                                                                       .toValue(show ? 1.0 : 0.0)
-                                                                       .duration(Duration.seconds(1))
-                                                                       .build())
-                                        .build();
+        ParallelTransition parallelTransition = new ParallelTransition();
+        ScaleTransition scaleTransition = new ScaleTransition();
+        scaleTransition.setNode(node());
+        scaleTransition.setFromX(from);
+        scaleTransition.setToX(to);
+        scaleTransition.setFromY(from);
+        scaleTransition.setToY(to);
+        scaleTransition.setDuration(Duration.seconds(1));
+        FadeTransition fadeTransition = new FadeTransition();
+        fadeTransition.setNode(node());
+        fadeTransition.setFromValue(show ? 0.0 : 1.0);
+        fadeTransition.setToValue(show ? 1.0 : 0.0);
+        fadeTransition.setDuration(Duration.seconds(1));
+        parallelTransition.getChildren().setAll(parallelTransition, fadeTransition);
+        return parallelTransition;
     }
 
     /**
@@ -496,29 +491,26 @@ public abstract class AbstractSlideModel<M extends AbstractSlideModel<M, V, S>, 
 
         final double angle = findAngle(fromX, toX, fromY, toY);
 
-        final MotionBlur mb = MotionBlurBuilder.create().angle(angle).build();
+        final MotionBlur mb = new MotionBlur();
+        mb.setAngle(angle);
         node().setEffect(mb);
-
-        return ParallelTransitionBuilder.create()
-                                        .children(
-                                                  TranslateTransitionBuilder.create()
-                                                                            .node(node())
-                                                                            .fromX(fromX)
-                                                                            .toX(toX)
-                                                                            .fromY(fromY)
-                                                                            .toY(toY)
-                                                                            .duration(Duration.seconds(1))
-                                                                            .build(),
-
-                                                  TimelineBuilder.create()
-                                                                 .keyFrames(
-                                                                            new KeyFrame(Duration.millis(0), new KeyValue(mb.radiusProperty(), 0)),
-                                                                            new KeyFrame(Duration.millis(100), new KeyValue(mb.radiusProperty(), 50)),
-                                                                            new KeyFrame(Duration.millis(500), new KeyValue(mb.radiusProperty(), 63)),
-                                                                            new KeyFrame(Duration.millis(900), new KeyValue(mb.radiusProperty(), 50)),
-                                                                            new KeyFrame(Duration.millis(1000), new KeyValue(mb.radiusProperty(), 0)))
-                                                                 .build())
-                                        .build();
+        ParallelTransition parallelTransition = new ParallelTransition();
+        TranslateTransition translateTransition = new TranslateTransition();
+        translateTransition.setNode(node());
+        translateTransition.setFromX(fromX);
+        translateTransition.setToX(toX);
+        translateTransition.setFromY(fromY);
+        translateTransition.setToY(toY);
+        translateTransition.setDuration(Duration.seconds(1));
+        Timeline timeline = new Timeline();
+        timeline.getKeyFrames().setAll(
+                new KeyFrame(Duration.millis(0), new KeyValue(mb.radiusProperty(), 0)),
+                new KeyFrame(Duration.millis(100), new KeyValue(mb.radiusProperty(), 50)),
+                new KeyFrame(Duration.millis(500), new KeyValue(mb.radiusProperty(), 63)),
+                new KeyFrame(Duration.millis(900), new KeyValue(mb.radiusProperty(), 50)),
+                new KeyFrame(Duration.millis(1000), new KeyValue(mb.radiusProperty(), 0)));
+        parallelTransition.getChildren().setAll(translateTransition, timeline);
+        return parallelTransition;
     }
 
     /**

--- a/org.jrebirth.af/presentation/src/main/java/org/jrebirth/af/presentation/ui/image/ImageSlideView.java
+++ b/org.jrebirth.af/presentation/src/main/java/org/jrebirth/af/presentation/ui/image/ImageSlideView.java
@@ -21,13 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import javafx.animation.Animation;
-import javafx.animation.FadeTransition;
-import javafx.animation.FadeTransitionBuilder;
-import javafx.animation.ParallelTransition;
-import javafx.animation.ParallelTransitionBuilder;
-import javafx.animation.PauseTransitionBuilder;
-import javafx.animation.SequentialTransitionBuilder;
+import javafx.animation.*;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.geometry.Insets;
@@ -36,9 +30,8 @@ import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.image.ImageViewBuilder;
 import javafx.scene.layout.StackPane;
-import javafx.scene.shape.RectangleBuilder;
+import javafx.scene.shape.Rectangle;
 import javafx.util.Duration;
 
 import org.jrebirth.af.api.exception.CoreException;
@@ -103,12 +96,13 @@ public final class ImageSlideView extends
         if (model().getSlide().getShowAnimation() == null ||
                 !"TileIn".equalsIgnoreCase(model().getSlide().getShowAnimation().value())
                         && !"TileIn60k".equalsIgnoreCase(model().getSlide().getShowAnimation().value())) {
-
-            node().getChildren().add(ImageViewBuilder.create()
-                                                            .image(this.image)
-                                                            .layoutX(0).layoutY(0)
-                                                            .fitWidth(this.image.getWidth()).fitHeight(this.image.getHeight())
-                                                            .build());
+            ImageView imageView = new ImageView();
+            imageView.setImage(this.image);
+            imageView.setLayoutX(0);
+            imageView.setLayoutY(0);
+            imageView.setFitWidth(this.image.getWidth());
+            imageView.setFitHeight(this.image.getHeight());
+            node().getChildren().add(imageView);
 
             // getRootNode().setOpacity(0);
 
@@ -158,12 +152,8 @@ public final class ImageSlideView extends
                 n.setOpacity(0.0);
             }
             this.tilePerRow = 5;
-
-            final ParallelTransition st = ParallelTransitionBuilder.create().children(
-                                                                                      getTileTransition(),
-                                                                                      getSlideLabelTransition(Duration.millis(1200)))
-                                                                   .build();
-
+            ParallelTransition st = new ParallelTransition();
+            st.getChildren().setAll(getTileTransition(), getSlideLabelTransition(Duration.millis(1200)));
             st.play();
         } else if (model().getSlide().getShowAnimation() != null && AnimationType.TILE_IN_60_K == model().getSlide().getShowAnimation()) {
             for (final Node n : node().getChildren()) {
@@ -171,10 +161,8 @@ public final class ImageSlideView extends
             }
             this.tilePerRow = 50;
 
-            final ParallelTransition st = ParallelTransitionBuilder.create().children(
-                                                                                      getTileTransition(),
-                                                                                      getSlideLabelTransition(Duration.millis(1200)))
-                                                                   .build();
+            final ParallelTransition st = new ParallelTransition();
+            st.getChildren().setAll(getTileTransition(), getSlideLabelTransition(Duration.millis(1200)));
 
             st.play();
         } else {
@@ -188,12 +176,13 @@ public final class ImageSlideView extends
      * @return
      */
     private FadeTransition getSlideLabelTransition(final Duration gap) {
-        return FadeTransitionBuilder.create()
-                                    .node(this.slideLabel)
-                                    .delay(gap)
-                                    .duration(Duration.millis(1200))
-                                    .fromValue(0).toValue(1)
-                                    .build();
+        FadeTransition fadeTransition = new FadeTransition();
+        fadeTransition.setNode(this.slideLabel);
+        fadeTransition.setDelay(gap);
+        fadeTransition.setDuration(Duration.millis(1200));
+        fadeTransition.setFromValue(0);
+        fadeTransition.setToValue(1);
+        return fadeTransition;
     }
 
     /**
@@ -201,11 +190,11 @@ public final class ImageSlideView extends
      */
     Animation getFadeTransition() {
         if (this.fadeTransition == null) {
-            this.fadeTransition = FadeTransitionBuilder.create()
-                                                       .node(node())
-                                                       .fromValue(0).toValue(1)
-                                                       .duration(Duration.seconds(1))
-                                                       .build();
+            this.fadeTransition = new FadeTransition();
+            ((FadeTransition) this.fadeTransition).setNode(node());
+            ((FadeTransition) this.fadeTransition).setFromValue(0);
+            ((FadeTransition) this.fadeTransition).setToValue(1);
+            ((FadeTransition) this.fadeTransition).setDuration(Duration.seconds(1));
         }
         return this.fadeTransition;
     }
@@ -228,34 +217,32 @@ public final class ImageSlideView extends
             for (double x = 0; x < width; x += tileWidth) {
                 for (double y = 0; y < height; y += tileHeight) {
 
-                    final ImageView iv = ImageViewBuilder
-                                                         .create()
-                                                         .image(getImage())
-                                                         .clip(RectangleBuilder.create().x(x).y(y)
-                                                                               .width(tileWidth).height(tileHeight)
-                                                                               .build())
-                                                         .opacity(0.0).layoutX(x)
-                                                         .layoutY(y).build();
+                    final ImageView iv = new ImageView();
+                    iv.setImage(getImage());
+                    Rectangle rectangle = new Rectangle();
+                    rectangle.setX(x);
+                    rectangle.setY(y);
+                    rectangle.setWidth(tileWidth);
+                    rectangle.setHeight(tileHeight);
+                    iv.setClip(rectangle);
+                    iv.setOpacity(0.0);
+                    iv.setLayoutX(x);
+                    iv.setLayoutY(y);
 
                     node().getChildren().add(iv);
-
-                    fades.add(SequentialTransitionBuilder
-                                                         .create()
-                                                         .children(
-                                                                   PauseTransitionBuilder.create()
-                                                                                         .duration(getRandomDuration())
-                                                                                         .build(),
-                                                                   FadeTransitionBuilder.create().node(iv)
-                                                                                        .fromValue(0.0).toValue(1.0)
-                                                                                        .duration(getRandomDuration())
-                                                                                        .build())
-                                                         .build());
+                    PauseTransition pauseTransition = new PauseTransition();
+                    pauseTransition.setDuration(getRandomDuration());
+                    FadeTransition fadeTransition = new FadeTransition();
+                    fadeTransition.setFromValue(0.0);
+                    fadeTransition.setToValue(1.0);
+                    fadeTransition.setDuration(getRandomDuration());
+                    fades.add(new SequentialTransition(pauseTransition, fadeTransition));
 
                 }
 
             }
-            this.tileTransition = ParallelTransitionBuilder.create()
-                                                           .children(fades).build();
+            this.tileTransition = new ParallelTransition();
+            ((ParallelTransition) this.tileTransition).getChildren().setAll(fades);
 
             this.tileTransition.setOnFinished(new EventHandler<ActionEvent>() {
 

--- a/org.jrebirth.af/presentation/src/main/java/org/jrebirth/af/presentation/ui/qanda/QandAView.java
+++ b/org.jrebirth.af/presentation/src/main/java/org/jrebirth/af/presentation/ui/qanda/QandAView.java
@@ -17,20 +17,14 @@
  */
 package org.jrebirth.af.presentation.ui.qanda;
 
-import javafx.animation.Animation;
-import javafx.animation.Interpolator;
-import javafx.animation.ParallelTransitionBuilder;
-import javafx.animation.ScaleTransitionBuilder;
-import javafx.animation.TranslateTransitionBuilder;
+import javafx.animation.*;
 import javafx.geometry.Pos;
 import javafx.scene.CacheHint;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.StackPane;
-import javafx.scene.layout.StackPaneBuilder;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextAlignment;
-import javafx.scene.text.TextBuilder;
 import javafx.util.Duration;
 
 import org.jrebirth.af.api.exception.CoreException;
@@ -73,35 +67,31 @@ public class QandAView extends AbstractSlideView<QandAModel, BorderPane, QandACo
 
         node().getStyleClass().add(model().getStyleClass() == null ? "qandaContainer" : model().getStyleClass());
 
-        this.firstText = TextBuilder.create()
+        this.firstText = new Text();
                                     // .text(getModel().getQuestion())
                                     // .styleClass("firstText")
-                                    .textAlignment(TextAlignment.JUSTIFY)
+        this.firstText.setTextAlignment(TextAlignment.JUSTIFY);
                                     // .wrappingWidth(600)
-                                    .smooth(true)
-                                    .cache(true)
-                                    .cacheHint(CacheHint.SPEED)
-                                    .fill(model().getStyleClass() == null ? Color.WHITE : PrezColors.SPLASH_TEXT.get())
-                                    .scaleX(1)
-                                    .scaleY(1)
-                                    .build();
+        this.firstText.setSmooth(true);
+        this.firstText.setCache(true);
+        this.firstText.setCacheHint(CacheHint.SPEED);
+        this.firstText.setFill(model().getStyleClass() == null ? Color.WHITE : PrezColors.SPLASH_TEXT.get());
+        this.firstText.setScaleX(1);
+        this.firstText.setScaleY(1);
 
-        this.secondText = TextBuilder.create()
+        this.secondText = new Text();
                                      // .text(getModel().getAnswer())
                                      // .styleClass("secondText")
-                                     .textAlignment(TextAlignment.JUSTIFY)
+        this.secondText.setTextAlignment(TextAlignment.JUSTIFY);
                                      // .wrappingWidth(600)
-                                     .smooth(true)
-                                     .cache(true)
-                                     .cacheHint(CacheHint.SPEED)
-                                     .fill(model().getStyleClass() == null ? Color.WHITE : PrezColors.SPLASH_TEXT.get())
-                                     .scaleX(0)
-                                     .scaleY(0)
-                                     .build();
+        this.secondText.setSmooth(true);
+        this.secondText.setCache(true);
+        this.secondText.setCacheHint(CacheHint.SPEED);
+        this.secondText.setFill(model().getStyleClass() == null ? Color.WHITE : PrezColors.SPLASH_TEXT.get());
+        this.secondText.setScaleX(0);
+        this.secondText.setScaleY(0);
 
-        final StackPane sp = StackPaneBuilder.create()
-                                             .children(this.firstText, this.secondText)
-                                             .build();
+        final StackPane sp = new StackPane(this.firstText, this.secondText);
 
         StackPane.setAlignment(this.firstText, Pos.CENTER);
         StackPane.setAlignment(this.secondText, Pos.CENTER);
@@ -124,44 +114,37 @@ public class QandAView extends AbstractSlideView<QandAModel, BorderPane, QandACo
      */
     Animation getTransition() {
         if (this.transition == null) {
-            this.transition =
-
-            ParallelTransitionBuilder.create().children(
-                                                        ScaleTransitionBuilder.create()
-                                                                              .node(this.firstText)
-                                                                              .duration(Duration.millis(800))
-                                                                              .interpolator(Interpolator.EASE_IN)
-                                                                              .fromX(1)
-                                                                              .fromY(1)
-                                                                              .toX(0)
-                                                                              .toY(0)
-                                                                              .build(),
-                                                        TranslateTransitionBuilder.create()
-                                                                                  .node(this.firstText)
-                                                                                  .duration(Duration.millis(800))
-                                                                                  .interpolator(Interpolator.EASE_IN)
-                                                                                  .fromY(0)
-                                                                                  .toY(600)
-                                                                                  .build(),
-                                                        ScaleTransitionBuilder.create()
-                                                                              .node(this.secondText)
-                                                                              // .delay(Duration.millis(200))
-                                                                              .duration(Duration.millis(1000))
-                                                                              .interpolator(Interpolator.EASE_IN)
-                                                                              .fromX(100)
-                                                                              .fromY(100)
-                                                                              .toX(1)
-                                                                              .toY(1)
-                                                                              .build(),
-                                                        TranslateTransitionBuilder.create()
-                                                                                  .node(this.secondText)
-                                                                                  .duration(Duration.millis(800))
-                                                                                  .interpolator(Interpolator.EASE_IN)
-                                                                                  .fromY(-600)
-                                                                                  .toY(0)
-                                                                                  .build())
-                                     .build();
-
+            ScaleTransition scaleTransition1 = new ScaleTransition();
+            scaleTransition1.setNode(this.firstText);
+            scaleTransition1.setDuration(Duration.millis(800));
+            scaleTransition1.setInterpolator(Interpolator.EASE_IN);
+            scaleTransition1.setFromX(1);
+            scaleTransition1.setFromY(1);
+            scaleTransition1.setToX(0);
+            scaleTransition1.setToY(0);
+            TranslateTransition translateTransition1 = new TranslateTransition();
+            translateTransition1.setNode(this.firstText);
+            translateTransition1.setDuration(Duration.millis(800));
+            translateTransition1.setInterpolator(Interpolator.EASE_IN);
+            translateTransition1.setFromY(0);
+            translateTransition1.setToY(600);
+            ScaleTransition scaleTransition2 = new ScaleTransition();
+            scaleTransition2.setNode(this.secondText);
+                    // .delay(Duration.millis(200))
+            scaleTransition2.setDuration(Duration.millis(1000));
+            scaleTransition2.setInterpolator(Interpolator.EASE_IN);
+            scaleTransition2.setFromX(100);
+            scaleTransition2.setFromY(100);
+            scaleTransition2.setToX(1);
+            scaleTransition2.setToY(1);
+            TranslateTransition translateTransition2 = new TranslateTransition();
+            translateTransition2.setNode(this.secondText);
+            translateTransition2.setDuration(Duration.millis(800));
+            translateTransition2.setInterpolator(Interpolator.EASE_IN);
+            translateTransition2.setFromY(-600);
+            translateTransition2.setToY(0);
+            this.transition = new ParallelTransition(scaleTransition1,
+                    translateTransition1, scaleTransition2, translateTransition2);
         }
         return this.transition;
     }

--- a/org.jrebirth.af/presentation/src/main/java/org/jrebirth/af/presentation/ui/splash/SplashView.java
+++ b/org.jrebirth.af/presentation/src/main/java/org/jrebirth/af/presentation/ui/splash/SplashView.java
@@ -19,14 +19,11 @@ package org.jrebirth.af.presentation.ui.splash;
 
 import javafx.animation.Interpolator;
 import javafx.animation.ScaleTransition;
-import javafx.animation.ScaleTransitionBuilder;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextAlignment;
-import javafx.scene.text.TextBuilder;
 import javafx.util.Duration;
-
 import org.jrebirth.af.api.exception.CoreException;
 import org.jrebirth.af.presentation.resources.PrezColors;
 import org.jrebirth.af.presentation.ui.base.AbstractSlideView;
@@ -65,16 +62,16 @@ public class SplashView extends AbstractSlideView<SplashModel, BorderPane, Splas
 
         node().getStyleClass().add(model().getStyleClass() == null ? "splashContainer" : model().getStyleClass());
 
-        this.splashText = TextBuilder.create()
-                                     .text(model().getTitle())
-                                     .styleClass("splashText")
-                                     .textAlignment(TextAlignment.JUSTIFY)
-                                     .wrappingWidth(600)
-                                     .smooth(true)
-                                     .fill(model().getStyleClass() == null ? Color.WHITE : PrezColors.SPLASH_TEXT.get())
-                                     .scaleX(0)
-                                     .scaleY(0)
-                                     .build();
+        this.splashText = new Text();
+
+        this.splashText.setText(model().getTitle());
+        this.splashText.getStyleClass().add("splashText");
+        this.splashText.setTextAlignment(TextAlignment.JUSTIFY);
+        this.splashText.setWrappingWidth(600);
+        this.splashText.setSmooth(true);
+        this.splashText.setFill(model().getStyleClass() == null ? Color.WHITE : PrezColors.SPLASH_TEXT.get());
+        this.splashText.setScaleX(0);
+        this.splashText.setScaleY(0);
 
         node().setCenter(this.splashText);
     }
@@ -100,15 +97,14 @@ public class SplashView extends AbstractSlideView<SplashModel, BorderPane, Splas
      */
     ScaleTransition getTextTransition() {
         if (this.textTransition == null) {
-            this.textTransition = ScaleTransitionBuilder.create()
-                                                        .node(this.splashText)
-                                                        .duration(Duration.millis(800))
-                                                        .interpolator(Interpolator.EASE_IN)
-                                                        .fromX(0)
-                                                        .fromY(0)
-                                                        .byX(2)
-                                                        .byY(2)
-                                                        .build();
+            this.textTransition = new ScaleTransition();
+            this.textTransition.setNode(this.splashText);
+            this.textTransition.setDuration(Duration.millis(800));
+            this.textTransition.setInterpolator(Interpolator.EASE_IN);
+            this.textTransition.setFromX(0);
+            this.textTransition.setFromY(0);
+            this.textTransition.setByX(2);
+            this.textTransition.setByY(2);
         }
         return this.textTransition;
     }

--- a/org.jrebirth.af/presentation/src/main/java/org/jrebirth/af/presentation/ui/stack/SlideStackModel.java
+++ b/org.jrebirth.af/presentation/src/main/java/org/jrebirth/af/presentation/ui/stack/SlideStackModel.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import javafx.animation.Animation;
 import javafx.animation.ParallelTransition;
-import javafx.animation.ParallelTransitionBuilder;
 import javafx.event.ActionEvent;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
@@ -208,7 +207,7 @@ public final class SlideStackModel extends DefaultModel<SlideStackModel, SlideSt
      * @return the animation to show
      */
     private ParallelTransition buildSlideTransition(final boolean isReverse, final SlideModel<SlideStep> previousSlideModel, final SlideModel<SlideStep> selectedSlideModel) {
-        final ParallelTransition slideAnimation = ParallelTransitionBuilder.create().build();
+        final ParallelTransition slideAnimation = new ParallelTransition();
 
         if (previousSlideModel != null) {
             final Animation a = isReverse ? previousSlideModel.getShowAnimation() : previousSlideModel.getHideAnimation();

--- a/org.jrebirth.af/presentation/src/main/java/org/jrebirth/af/presentation/ui/template/AbstractTemplateView.java
+++ b/org.jrebirth.af/presentation/src/main/java/org/jrebirth/af/presentation/ui/template/AbstractTemplateView.java
@@ -2,13 +2,13 @@
  * Get more info at : www.jrebirth.org .
  * Copyright JRebirth.org © 2011-2013
  * Contact : sebastien.bordes@jrebirth.org
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,18 +17,8 @@
  */
 package org.jrebirth.af.presentation.ui.template;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javafx.animation.Animation;
-import javafx.animation.KeyFrame;
-import javafx.animation.KeyValue;
-import javafx.animation.ParallelTransitionBuilder;
-import javafx.animation.RotateTransitionBuilder;
-import javafx.animation.ScaleTransitionBuilder;
-import javafx.animation.SequentialTransitionBuilder;
-import javafx.animation.TimelineBuilder;
-import javafx.animation.TranslateTransitionBuilder;
+import com.sun.javafx.fxml.builder.web.WebViewBuilder;
+import javafx.animation.*;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.NumberBinding;
 import javafx.event.ActionEvent;
@@ -36,37 +26,20 @@ import javafx.event.EventHandler;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Hyperlink;
-import javafx.scene.control.HyperlinkBuilder;
 import javafx.scene.control.Label;
-import javafx.scene.control.LabelBuilder;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.image.ImageViewBuilder;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
-import javafx.scene.layout.AnchorPane;
-import javafx.scene.layout.AnchorPaneBuilder;
-import javafx.scene.layout.Pane;
-import javafx.scene.layout.PaneBuilder;
-import javafx.scene.layout.Priority;
-import javafx.scene.layout.Region;
-import javafx.scene.layout.StackPane;
-import javafx.scene.layout.StackPaneBuilder;
-import javafx.scene.layout.VBox;
+import javafx.scene.layout.*;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
-import javafx.scene.shape.CircleBuilder;
 import javafx.scene.shape.Polyline;
-import javafx.scene.shape.PolylineBuilder;
 import javafx.scene.shape.Rectangle;
-import javafx.scene.shape.RectangleBuilder;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextAlignment;
-import javafx.scene.text.TextBuilder;
 import javafx.scene.web.WebView;
-import javafx.scene.web.WebViewBuilder;
 import javafx.util.Duration;
-
 import org.jrebirth.af.api.exception.CoreException;
 import org.jrebirth.af.core.resource.Resources;
 import org.jrebirth.af.core.resource.image.RelImage;
@@ -77,6 +50,9 @@ import org.jrebirth.af.presentation.resources.PrezFonts;
 import org.jrebirth.af.presentation.resources.PrezImages;
 import org.jrebirth.af.presentation.ui.base.AbstractSlideView;
 import org.jrebirth.af.presentation.ui.base.SlideStep;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  *
@@ -239,45 +215,33 @@ public abstract class AbstractTemplateView<M extends AbstractTemplateModel<?, ?,
      */
     @Override
     public void reload() {
+        ParallelTransition parallelTransition = new ParallelTransition();
+        ScaleTransition scaleTransition = new ScaleTransition();
+        scaleTransition.setNode(this.circle);
+        scaleTransition.setDuration(Duration.millis(600));
+        scaleTransition.setFromY(0);
+        scaleTransition.setFromY(0);
+        scaleTransition.setToX(1);
+        scaleTransition.setToY(1);
+        Timeline timeline = new Timeline();
+        timeline.setDelay(Duration.millis(200));
+        timeline.getKeyFrames().setAll(
+                new KeyFrame(Duration.millis(0), new KeyValue(this.rectangle.widthProperty(), 0)),
+                new KeyFrame(Duration.millis(600), new KeyValue(this.rectangle.widthProperty(), 90)));
+        ParallelTransition parallelTransition1 = new ParallelTransition();
+        RotateTransition rotateTransition = new RotateTransition();
 
-        ParallelTransitionBuilder.create().children(
-
-                                                    // ParallelTransitionBuilder.create().children(
-                                                    ScaleTransitionBuilder
-                                                                          .create()
-                                                                          .node(this.circle)
-                                                                          .duration(Duration.millis(600))
-                                                                          .fromX(0)
-                                                                          .fromY(0)
-                                                                          .toX(1)
-                                                                          .toY(1)
-                                                                          .build(),
-                                                    TimelineBuilder.create()
-                                                                   .delay(Duration.millis(200))
-                                                                   .keyFrames(
-                                                                              new KeyFrame(Duration.millis(0), new KeyValue(this.rectangle.widthProperty(), 0)),
-                                                                              new KeyFrame(Duration.millis(600), new KeyValue(this.rectangle.widthProperty(), 90)))
-                                                                   .build(),
-                                                    ParallelTransitionBuilder
-                                                                             .create().delay(Duration.millis(400))
-                                                                             .children(
-                                                                                       RotateTransitionBuilder
-                                                                                                              .create()
-                                                                                                              .duration(Duration.millis(600))
-                                                                                                              .fromAngle(-180)
-                                                                                                              .toAngle(0)
-                                                                                                              .build(),
-                                                                                       ScaleTransitionBuilder
-                                                                                                             .create()
-                                                                                                             .duration(Duration.millis(600))
-                                                                                                             .fromX(0)
-                                                                                                             .fromY(0)
-                                                                                                             .toX(1)
-                                                                                                             .toY(1)
-                                                                                                             .build())
-                                                                             .node(this.slideContent)
-                                                                             .build())
-                                 .build().play();
+        rotateTransition.setFromAngle(-180);
+        rotateTransition.setToAngle(0);
+        ScaleTransition scaleTransition1 = new ScaleTransition();
+        scaleTransition1.setDuration(Duration.millis(600));
+        scaleTransition1.setFromX(0);
+        scaleTransition1.setFromY(0);
+        scaleTransition1.setToX(1);
+        scaleTransition1.setToY(1);
+        parallelTransition1.setDelay(Duration.millis(400));
+        parallelTransition1.getChildren().setAll(rotateTransition, scaleTransition1);
+        parallelTransition.getChildren().setAll(scaleTransition, timeline, parallelTransition1);
     }
 
     /**
@@ -287,77 +251,70 @@ public abstract class AbstractTemplateView<M extends AbstractTemplateModel<?, ?,
      */
     protected Node getHeaderPanel() {
 
-        final Pane headerPane = PaneBuilder.create()
-                                           .styleClass("header")
-                                           .layoutX(0.0)
-                                           .layoutY(0.0)
-                                           .minWidth(1024)
-                                           .prefWidth(1024)
-                                           .build();
+        final Pane headerPane = new Pane();
+        headerPane.getStyleClass().add("header");
+        headerPane.setLayoutX(0.0);
+        headerPane.setLayoutY(0.0);
+        headerPane.minWidth(1024);
+        headerPane.prefWidth(1024);
         // sp.getStyleClass().add("header");
 
-        final Label primaryTitle = LabelBuilder.create()
-                                               // .styleClass("slideTitle")
-                                               .font(PrezFonts.SLIDE_TITLE.get())
-                                               .textFill(PrezColors.SLIDE_TITLE.get())
-                                               .text(model().getSlide().getTitle().replaceAll("\\\\n", "\n").replaceAll("\\\\t", "\t"))
-                                               .layoutX(40)
-                                               .layoutY(45)
-                                               // .style("-fx-background-color:#CCCB20")
-                                               .build();
+        final Label primaryTitle = new Label();
+        // .styleClass("slideTitle")
+        primaryTitle.setFont(PrezFonts.SLIDE_TITLE.get());
+        primaryTitle.setTextFill(PrezColors.SLIDE_TITLE.get());
+        primaryTitle.setText(model().getSlide().getTitle().replaceAll("\\\\n", "\n").replaceAll("\\\\t", "\t"));
+        primaryTitle.setLayoutX(40);
+        primaryTitle.setLayoutY(45);
+        // .style("-fx-background-color:#CCCB20")
 
-        this.secondaryTitle = LabelBuilder.create()
-                                          // .styleClass("slideTitle")
-                                          .font(PrezFonts.SLIDE_SUB_TITLE.get())
-                                          .textFill(PrezColors.SLIDE_TITLE.get())
-                                          // .scaleX(1.5)
-                                          // .scaleY(1.5)
-                                          .layoutX(450)
-                                          .layoutY(14)
-                                          .minWidth(450)
-                                          // .style("-fx-background-color:#E53B20")
-                                          .alignment(Pos.CENTER_RIGHT)
-                                          .textAlignment(TextAlignment.RIGHT)
-                                          .build();
+        this.secondaryTitle = new Label();
+        // .styleClass("slideTitle")
+        this.secondaryTitle.setFont(PrezFonts.SLIDE_SUB_TITLE.get());
+        this.secondaryTitle.setTextFill(PrezColors.SLIDE_TITLE.get());
+        // .scaleX(1.5)
+        // .scaleY(1.5)
+        this.secondaryTitle.setLayoutX(450);
+        this.secondaryTitle.setLayoutY(14);
+        this.secondaryTitle.setMinWidth(450);
+        // .style("-fx-background-color:#E53B20")
+        this.secondaryTitle.setAlignment(Pos.CENTER_RIGHT);
+        this.secondaryTitle.setTextAlignment(TextAlignment.RIGHT);
 
-        final ImageView breizhcamp = ImageViewBuilder.create()
-                                                     .layoutX(680.0)
-                                                     .layoutY(-14.0)
-                                                     .scaleX(0.6)
-                                                     .scaleY(0.6)
-                                                     .image(PrezImages.HEADER_LOGO.get())
-                                                     .build();
+        final ImageView breizhcamp = new ImageView();
+        breizhcamp.setLayoutX(680.0);
+        breizhcamp.setLayoutY(-14.0);
+        breizhcamp.setScaleX(0.6);
+        breizhcamp.setScaleY(0.6);
+        breizhcamp.setImage(PrezImages.HEADER_LOGO.get());
 
-        final Polyline pl = PolylineBuilder.create()
-                                           .strokeWidth(3)
-                                           .stroke(Color.BLACK)
-                                           .points(684.0, 12.0, 946.0, 12.0, 946.0, 107.0)
-                                           .build();
+        final Polyline pl = new Polyline();
+        pl.setStrokeWidth(3);
+        pl.setStroke(Color.BLACK);
+        pl.getPoints().setAll(684.0, 12.0, 946.0, 12.0, 946.0, 107.0);
 
-        this.rectangle = RectangleBuilder.create()
-                                         .layoutX(108.0)
-                                         .layoutY(95.0)
-                                         .width(0.0) // 60.0
-                                         .height(14.0)
-                                         .fill(Color.web("1C9A9A"))
-                                         .build();
+        this.rectangle = new Rectangle();
+        this.rectangle.setLayoutX(108.0);
+        this.rectangle.setLayoutY(95.0);
+        this.rectangle.setWidth(0.0); // 60.0
+        this.rectangle.setHeight(14.0);
+        ;
+        this.rectangle.setFill(Color.web("1C9A9A"));
 
-        this.circle = CircleBuilder.create()
-                                   .scaleX(0)
-                                   .scaleY(0)
-                                   .layoutX(18 + 54)
-                                   .layoutY(18 + 54)
-                                   .radius(54)
-                                   .fill(Color.web("444442"))
-                                   .build();
+        this.circle = new Circle();
+        this.circle.setScaleX(0);
+        this.circle.setScaleY(0);
+        this.circle.setLayoutX(18 + 54);
+        this.circle.setLayoutY(18 + 54);
+        this.circle.setRadius(54);
+        this.circle.setFill(Color.web("444442"));
 
-        this.pageLabel = LabelBuilder.create()
-                                     .layoutX(970)
-                                     .layoutY(18.0)
-                                     .text(String.valueOf(model().getSlide().getPage()))
-                                     .font(PrezFonts.PAGE.get())
-                                     .rotate(90.0)
-                                     .build();
+        this.pageLabel = new Label();
+        this.pageLabel.setLayoutX(970);
+        this.pageLabel.setLayoutY(18.0);
+        this.pageLabel.setText(String.valueOf(model().getSlide().getPage()));
+        this.pageLabel.setFont(PrezFonts.PAGE.get());
+        this.pageLabel.setRotate(90.0);
 
         // final FlowPane fp = FlowPaneBuilder.create()
         // .orientation(Orientation.HORIZONTAL)
@@ -425,23 +382,19 @@ public abstract class AbstractTemplateView<M extends AbstractTemplateModel<?, ?,
      * @return the footer panel
      */
     protected Node getFooterPanel() {
-        this.pageLabel = LabelBuilder.create()
-                                     .text(String.valueOf(model().getSlide().getPage()))
-                                     .font(PrezFonts.PAGE.get())
-                                     .build();
+        this.pageLabel = new Label();
+        this.pageLabel.setText(String.valueOf(model().getSlide().getPage()));
+        this.pageLabel.setFont(PrezFonts.PAGE.get());
 
-        final AnchorPane ap = AnchorPaneBuilder.create()
-                                               .children(this.pageLabel)
-                                               .build();
+        final AnchorPane ap = new AnchorPane(this.pageLabel);
         AnchorPane.setRightAnchor(this.pageLabel, 20.0);
 
-        final StackPane sp = StackPaneBuilder.create()
-                                             .styleClass("footer")
-                                             .prefHeight(35.0)
-                                             .minHeight(Region.USE_PREF_SIZE)
-                                             .maxHeight(Region.USE_PREF_SIZE)
-                                             .children(ap)
-                                             .build();
+        final StackPane sp = new StackPane();
+        sp.getStyleClass().add("footer");
+        sp.setPrefHeight(35.0);
+        sp.setMinHeight(Region.USE_PREF_SIZE);
+        sp.setMaxHeight(Region.USE_PREF_SIZE);
+        sp.getChildren().addAll(ap);
 
         StackPane.setAlignment(ap, Pos.CENTER_RIGHT);
 
@@ -490,10 +443,9 @@ public abstract class AbstractTemplateView<M extends AbstractTemplateModel<?, ?,
         Node node = null;
         if (item.isLink()) {
 
-            final Hyperlink link = HyperlinkBuilder.create()
-                                                   .opacity(1.0)
-                                                   .text(item.getValue())
-                                                   .build();
+            final Hyperlink link = new Hyperlink();
+            link.setOpacity(1.0);
+            link.setText(item.getValue());
 
             link.getStyleClass().add("link" + item.getLevel());
 
@@ -510,9 +462,9 @@ public abstract class AbstractTemplateView<M extends AbstractTemplateModel<?, ?,
         } else if (item.isHtml()) {
 
             final WebView web = WebViewBuilder.create()
-                                              .fontScale(1.4)
-                                              // .effect(ReflectionBuilder.create().fraction(0.4).build())
-                                              .build();
+                    .fontScale(1.4)
+                    // .effect(ReflectionBuilder.create().fraction(0.4).build())
+                    .build();
             web.getEngine().loadContent(item.getValue());
 
             VBox.setVgrow(web, Priority.NEVER);
@@ -522,19 +474,17 @@ public abstract class AbstractTemplateView<M extends AbstractTemplateModel<?, ?,
         } else if (item.getImage() != null) {
 
             final Image image = Resources.create(new RelImage(item.getImage())).get();
-            final ImageView imageViewer = ImageViewBuilder.create()
-                                                          .styleClass(ITEM_CLASS_PREFIX + item.getLevel())
-                                                          .image(image)
-                                                          // .effect(ReflectionBuilder.create().fraction(0.9).build())
-                                                          .build();
+            final ImageView imageViewer = new ImageView();
+            imageViewer.getStyleClass().add(ITEM_CLASS_PREFIX + item.getLevel());
+            imageViewer.setImage(image);
+            // .effect(ReflectionBuilder.create().fraction(0.9).build())
 
             node = imageViewer;
         } else {
 
-            final Text text = TextBuilder.create()
-                                         .styleClass(ITEM_CLASS_PREFIX + item.getLevel())
-                                         .text(item.getValue() == null ? "" : item.getValue())
-                                         .build();
+            final Text text = new Text();
+            text.getStyleClass().add(ITEM_CLASS_PREFIX + item.getLevel());
+            text.setText(item.getValue() == null ? "" : item.getValue());
 
             node = text;
         }
@@ -610,66 +560,51 @@ public abstract class AbstractTemplateView<M extends AbstractTemplateModel<?, ?,
     private void performStepAnimation(final Node nextSlide) {
 
         // setSlideLocked(true);
-        this.slideStepAnimation = ParallelTransitionBuilder.create()
+        this.slideStepAnimation = new ParallelTransition();
+        this.slideStepAnimation.setOnFinished(new EventHandler<ActionEvent>() {
 
-                                                           .onFinished(new EventHandler<ActionEvent>() {
-
-                                                               @Override
-                                                               public void handle(final ActionEvent event) {
-                                                                   AbstractTemplateView.this.currentSubSlide = nextSlide;
-                                                                   // AbstractTemplateView.this.setSlideLocked(false);
-                                                               }
-                                                           })
-
-                                                           .children(
-                                                                     SequentialTransitionBuilder.create()
-                                                                                                .node(this.currentSubSlide)
-                                                                                                .children(
-                                                                                                          TranslateTransitionBuilder.create()
-                                                                                                                                    .duration(Duration.millis(400))
-                                                                                                                                    .fromY(0)
-                                                                                                                                    .toY(-700)
-                                                                                                                                    // .fromZ(-10)
-                                                                                                                                    .build(),
-                                                                                                          TimelineBuilder.create()
-                                                                                                                         .keyFrames(
-                                                                                                                                    new KeyFrame(
-                                                                                                                                                 Duration.millis(0),
-                                                                                                                                                 new KeyValue(
-                                                                                                                                                              this.currentSubSlide.visibleProperty(),
-                                                                                                                                                              true)),
-                                                                                                                                    new KeyFrame(
-                                                                                                                                                 Duration.millis(1),
-                                                                                                                                                 new KeyValue(
-                                                                                                                                                              this.currentSubSlide.visibleProperty(),
-                                                                                                                                                              false)))
-                                                                                                                         .build())
-
-                                                                                                .build(),
-                                                                     SequentialTransitionBuilder.create()
-                                                                                                .node(nextSlide)
-                                                                                                .children(
-                                                                                                          TimelineBuilder.create()
-                                                                                                                         .keyFrames(
-                                                                                                                                    new KeyFrame(
-                                                                                                                                                 Duration.millis(0),
-                                                                                                                                                 new KeyValue(
-                                                                                                                                                              nextSlide.visibleProperty(),
-                                                                                                                                                              false)),
-                                                                                                                                    new KeyFrame(
-                                                                                                                                                 Duration.millis(1),
-                                                                                                                                                 new KeyValue(
-                                                                                                                                                              nextSlide.visibleProperty(),
-                                                                                                                                                              true)))
-                                                                                                                         .build(),
-                                                                                                          TranslateTransitionBuilder.create()
-                                                                                                                                    .duration(Duration.millis(400))
-                                                                                                                                    .fromY(700)
-                                                                                                                                    .toY(0)
-                                                                                                                                    // .fromZ(-10)
-                                                                                                                                    .build())
-                                                                                                .build())
-                                                           .build();
+            @Override
+            public void handle(final ActionEvent event) {
+                AbstractTemplateView.this.currentSubSlide = nextSlide;
+                // AbstractTemplateView.this.setSlideLocked(false);
+            }
+        });
+        TranslateTransition translateTransition = new TranslateTransition();
+        translateTransition.setDuration(Duration.millis(400));
+        translateTransition.setFromY(0);
+        translateTransition.setToY(-700);
+        Timeline timeline = new Timeline();
+        timeline.getKeyFrames().setAll(
+                new KeyFrame(
+                        Duration.millis(0),
+                        new KeyValue(
+                                this.currentSubSlide.visibleProperty(),
+                                true)),
+                new KeyFrame(
+                        Duration.millis(1),
+                        new KeyValue(
+                                this.currentSubSlide.visibleProperty(),
+                                false)));
+        Timeline timeline1 = new Timeline();
+        timeline1.getKeyFrames().setAll(
+                new KeyFrame(
+                        Duration.millis(0),
+                        new KeyValue(
+                                nextSlide.visibleProperty(),
+                                false)),
+                new KeyFrame(
+                        Duration.millis(1),
+                        new KeyValue(
+                                nextSlide.visibleProperty(),
+                                true)));
+        TranslateTransition translateTransition1 = new TranslateTransition();
+        translateTransition1.setDuration(Duration.millis(400));
+        translateTransition1.setFromY(700);
+        translateTransition1.setToY(0);
+        ((ParallelTransition) this.slideStepAnimation).getChildren().setAll(
+                new SequentialTransition(this.currentSubSlide, translateTransition, timeline),
+                new SequentialTransition(nextSlide, timeline1, translateTransition1)
+        );
         this.slideStepAnimation.play();
 
     }

--- a/org.jrebirth.af/sample/src/main/java/org/jrebirth/af/sample/command/SampleUICommand.java
+++ b/org.jrebirth.af/sample/src/main/java/org/jrebirth/af/sample/command/SampleUICommand.java
@@ -1,11 +1,9 @@
 package org.jrebirth.af.sample.command;
 
-import javafx.scene.SceneBuilder;
-import javafx.scene.control.LabelBuilder;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
 import javafx.stage.Stage;
-import javafx.stage.StageBuilder;
 import javafx.stage.StageStyle;
-
 import org.jrebirth.af.api.wave.Wave;
 import org.jrebirth.af.api.wave.WaveBean;
 import org.jrebirth.af.core.command.single.ui.DefaultUIBeanCommand;
@@ -17,7 +15,9 @@ import org.slf4j.LoggerFactory;
  */
 public final class SampleUICommand extends DefaultUIBeanCommand<WaveBean> {
 
-    /** The class logger. */
+    /**
+     * The class logger.
+     */
     private static final Logger LOGGER = LoggerFactory.getLogger(SampleUICommand.class);
 
     /**
@@ -36,14 +36,10 @@ public final class SampleUICommand extends DefaultUIBeanCommand<WaveBean> {
 
         LOGGER.info("Display a pop up from JAT");
 
-        final Stage s = StageBuilder.create()
-                                    .title("Sample Ui Command Test")
-                                    .style(StageStyle.DECORATED)
-                                    .scene(SceneBuilder.create()
-                                                       .root(LabelBuilder.create().text("Run into JAT").build())
-                                                       .build())
-
-                                    .build();
+        final Stage s = new Stage();
+        s.setTitle("Sample Ui Command Test");
+        s.initStyle(StageStyle.DECORATED);
+        s.setScene(new Scene(new Label("Run into JAT")));
 
         s.show();
         // Sample for popup => Attach owner !!!

--- a/org.jrebirth.af/sample/src/main/java/org/jrebirth/af/sample/ui/SampleView.java
+++ b/org.jrebirth.af/sample/src/main/java/org/jrebirth/af/sample/ui/SampleView.java
@@ -1,15 +1,13 @@
 package org.jrebirth.af.sample.ui;
 
 import javafx.scene.control.Button;
-import javafx.scene.control.LabelBuilder;
+import javafx.scene.control.Label;
 import javafx.scene.layout.BorderPane;
-import javafx.scene.layout.FlowPaneBuilder;
-
+import javafx.scene.layout.FlowPane;
 import org.jrebirth.af.api.exception.CoreException;
 import org.jrebirth.af.api.ui.annotation.OnMouse;
 import org.jrebirth.af.api.ui.annotation.type.Mouse;
 import org.jrebirth.af.core.ui.AbstractView;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,17 +51,12 @@ public final class SampleView extends AbstractView<SampleModel, BorderPane, Samp
         this.defaultCommand = new Button("Trigger a default Command into JIT");
         this.uiCommand = new Button("Trigger an UI Command into JAT");
         this.pooledCommand = new Button("Trigger a pooled Command into JTP");
+        node().setCenter(new Label("JRebirth Sample"));
 
-        node().setCenter(
-                         LabelBuilder.create()
-                                     .text("JRebirth Sample")
-                                     .build());
-
-        node().setBottom(FlowPaneBuilder.create().children(
+        node().setBottom(new FlowPane(
                                                            this.defaultCommand,
                                                            this.uiCommand,
-                                                           this.pooledCommand)
-                                        .build());
+                                                           this.pooledCommand));
     }
 
     /**

--- a/org.jrebirth.af/showcase/analyzer/src/main/java/org/jrebirth/af/showcase/analyzer/ui/editor/ball/BallView.java
+++ b/org.jrebirth.af/showcase/analyzer/src/main/java/org/jrebirth/af/showcase/analyzer/ui/editor/ball/BallView.java
@@ -19,21 +19,17 @@ package org.jrebirth.af.showcase.analyzer.ui.editor.ball;
 
 import javafx.animation.Animation;
 import javafx.animation.ParallelTransition;
-import javafx.animation.ParallelTransitionBuilder;
 import javafx.animation.ScaleTransition;
-import javafx.animation.ScaleTransitionBuilder;
-import javafx.animation.TranslateTransitionBuilder;
+import javafx.animation.TranslateTransition;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.scene.control.Label;
-import javafx.scene.control.LabelBuilder;
 import javafx.scene.effect.BlurType;
-import javafx.scene.effect.DropShadowBuilder;
-import javafx.scene.effect.InnerShadowBuilder;
+import javafx.scene.effect.DropShadow;
+import javafx.scene.effect.InnerShadow;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
-import javafx.scene.shape.CircleBuilder;
 import javafx.util.Duration;
 
 import org.jrebirth.af.api.exception.CoreException;
@@ -88,41 +84,33 @@ public final class BallView extends DefaultView<BallModel, StackPane, BallContro
         node().setScaleX(0);
         node().setScaleY(0);
 
-        this.circle = CircleBuilder.create()
-                                   .radius(22)
-                                   .fill(Color.ALICEBLUE)
-                                   .stroke(Color.WHITE)
-                                   .strokeWidth(4)
-                                   .build();
+        this.circle = new Circle();
+        this.circle.setRadius(22);
+        this.circle.setFill(Color.ALICEBLUE);
+        this.circle.setStroke(Color.WHITE);
+        this.circle.setStrokeWidth(4);
 
-        this.label = LabelBuilder.create()
-                                 .textFill(Color.WHITE)
-                                 // .effect(arg0)
-                                 .build();
+        this.label = new Label();
+        this.label.setTextFill(Color.WHITE);
 
         node().getChildren().addAll(this.circle, this.label);
-
-        this.showTransition = ParallelTransitionBuilder.create()
-                                                       .children(
-                                                                 ScaleTransitionBuilder.create()
-                                                                                       .duration(Duration.millis(400))
-                                                                                       .node(node())
-                                                                                       .fromX(0.0)
-                                                                                       .fromY(0.0)
-                                                                                       .toX(1f)
-                                                                                       .toY(1f)
-                                                                                       .build(),
-                                                                 TranslateTransitionBuilder.create()
-                                                                                           .duration(Duration.millis(500))
-                                                                                           .node(node())
-                                                                                           .fromX(0.0)
-                                                                                           .fromY(0.0)
-                                                                                           .toX(getX())
-                                                                                           .toY(getY())
-                                                                                           .build())
-                                                       .cycleCount(1)
-                                                       .autoReverse(false)
-                                                       .build();
+        ScaleTransition scaleTransition = new ScaleTransition();
+        scaleTransition.setDuration(Duration.millis(400));
+        scaleTransition.setNode(node());
+        scaleTransition.setFromX(0.0);
+        scaleTransition.setFromY(0.0);
+        scaleTransition.setToX(1f);
+        scaleTransition.setToY(1f);
+        TranslateTransition translateTransition = new TranslateTransition();
+        translateTransition.setDuration(Duration.millis(500));
+        translateTransition.setNode(node());
+        translateTransition.setFromX(0.0);
+        translateTransition.setFromY(0.0);
+        translateTransition.setToX(getX());
+        translateTransition.setToY(getY());
+        this.showTransition = new ParallelTransition(scaleTransition, translateTransition);
+        this.showTransition.setCycleCount(1);
+        this.showTransition.setAutoReverse(false);
 
         this.showTransition.setOnFinished(new EventHandler<ActionEvent>() {
 
@@ -133,33 +121,30 @@ public final class BallView extends DefaultView<BallModel, StackPane, BallContro
             }
         });
 
-        this.scaleTransition = ScaleTransitionBuilder.create()
-                                                     .duration(Duration.millis(600))
-                                                     .node(node())
-                                                     .fromX(1.1)
-                                                     .fromY(1.1)
-                                                     .toX(0.7)
-                                                     .toY(0.7)
-                                                     .cycleCount(Animation.INDEFINITE)
-                                                     .autoReverse(true)
-                                                     .build();
+        this.scaleTransition = new ScaleTransition();
+        this.scaleTransition.setDuration(Duration.millis(600));
+        this.scaleTransition.setNode(node());
+        this.scaleTransition.setFromX(1.1);
+        this.scaleTransition.setFromY(1.1);
+        this.scaleTransition.setToX(0.7);
+        this.scaleTransition.setToY(0.7);
+        this.scaleTransition.setCycleCount(Animation.INDEFINITE);
+        this.scaleTransition.setAutoReverse(true);
+        InnerShadow innerShadow = new InnerShadow();
+        innerShadow.setColor(Color.GREY);
+        innerShadow.setBlurType(BlurType.GAUSSIAN);
+        innerShadow.setRadius(2);
+        innerShadow.setOffsetX(1);
+        innerShadow.setOffsetY(1);
+        this.circle.setEffect(innerShadow);
 
-        this.circle.setEffect(InnerShadowBuilder.create()
-                                                .color(Color.GREY)
-                                                .blurType(BlurType.GAUSSIAN)
-                                                .radius(2)
-                                                .offsetX(1)
-                                                .offsetY(1)
-                                                .build());
-
-        node().setEffect(DropShadowBuilder.create()
-                                          // .input()
-                                          .color(Color.BLACK)
-                                          .blurType(BlurType.GAUSSIAN)
-                                          .radius(4)
-                                          .offsetX(3)
-                                          .offsetY(3)
-                                          .build());
+        DropShadow dropShadow = new DropShadow();
+        dropShadow.setColor(Color.BLACK);
+        dropShadow.setBlurType(BlurType.GAUSSIAN);
+        dropShadow.setRadius(4);
+        dropShadow.setOffsetX(3);
+        dropShadow.setOffsetY(3);
+        node().setEffect(dropShadow);
 
     }
 
@@ -228,15 +213,14 @@ public final class BallView extends DefaultView<BallModel, StackPane, BallContro
      * To complete.
      */
     public void resetScale() {
-        ScaleTransitionBuilder.create()
-                              .duration(Duration.millis(400))
-                              .node(node())
-                              .toX(1f)
-                              .toY(1f)
-                              .cycleCount(1)
-                              .autoReverse(false)
-                              .build()
-                              .play();
+        ScaleTransition scaleTransition = new ScaleTransition();
+        scaleTransition.setDuration(Duration.millis(400));
+        scaleTransition.setNode(node());
+        scaleTransition.setToX(1f);
+        scaleTransition.setToY(1f);
+        scaleTransition.setCycleCount(1);
+        scaleTransition.setAutoReverse(false);
+        scaleTransition.play();
     }
 
     /**

--- a/org.jrebirth.af/showcase/analyzer/src/main/java/org/jrebirth/af/showcase/analyzer/ui/properties/PropertiesView.java
+++ b/org.jrebirth.af/showcase/analyzer/src/main/java/org/jrebirth/af/showcase/analyzer/ui/properties/PropertiesView.java
@@ -19,7 +19,6 @@ package org.jrebirth.af.showcase.analyzer.ui.properties;
 
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
-import javafx.scene.layout.HBoxBuilder;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 
@@ -58,7 +57,7 @@ public final class PropertiesView extends DefaultView<PropertiesModel, VBox, Pro
 
         node().setMinWidth(200);
 
-        final HBox hbox = HBoxBuilder.create().build();
+        final HBox hbox = new HBox();
         final Label label = new Label("Node Name :");
         this.nodeName = new Text();
         hbox.getChildren().addAll(label, this.nodeName);

--- a/org.jrebirth.af/showcase/undoredo/src/main/java/org/jrebirth/af/showcase/undoredo/command/CreateShapeCommand.java
+++ b/org.jrebirth.af/showcase/undoredo/src/main/java/org/jrebirth/af/showcase/undoredo/command/CreateShapeCommand.java
@@ -19,9 +19,8 @@ package org.jrebirth.af.showcase.undoredo.command;
 
 import javafx.scene.Node;
 import javafx.scene.paint.Color;
-import javafx.scene.shape.CircleBuilder;
-import javafx.scene.shape.RectangleBuilder;
-
+import javafx.scene.shape.Circle;
+import javafx.scene.shape.Rectangle;
 import org.jrebirth.af.api.concurrent.RunInto;
 import org.jrebirth.af.api.concurrent.RunType;
 import org.jrebirth.af.api.wave.Wave;
@@ -61,13 +60,27 @@ public class CreateShapeCommand extends DefaultUndoableCommand<WaveBean> {
         // Build a node according to the shape type
         switch (this.shapeType) {
             case Circle:
-                this.createdNode = CircleBuilder.create().fill(Color.BLUE).layoutX(60).layoutY(60).radius(30).build();
+                this.createdNode = new Circle();
+                ((Circle)this.createdNode).setFill(Color.BLUE);
+                this.createdNode.setLayoutY(60);
+                this.createdNode.setLayoutY(60);
+                ((Circle)this.createdNode).setRadius(30);
                 break;
             case Square:
-                this.createdNode = RectangleBuilder.create().fill(Color.BLUEVIOLET).layoutX(50).layoutY(100).width(30).height(30).build();
+                this.createdNode = new Rectangle();
+                ((Rectangle) this.createdNode).setFill(Color.BLUEVIOLET);
+                this.createdNode.setLayoutX(50);
+                this.createdNode.setLayoutY(100);
+                ((Rectangle) this.createdNode).setWidth(30);
+                ((Rectangle) this.createdNode).setHeight(30);
                 break;
             case Rectangle:
-                this.createdNode = RectangleBuilder.create().fill(Color.AZURE).layoutX(100).layoutY(150).width(30).height(15).build();
+                this.createdNode = new Rectangle();
+                ((Rectangle) this.createdNode).setFill(Color.AZURE);
+                this.createdNode.setLayoutX(100);
+                this.createdNode.setLayoutY(150);
+                ((Rectangle) this.createdNode).setWidth(30);
+                ((Rectangle) this.createdNode).setHeight(15);
                 break;
         }
 

--- a/org.jrebirth.af/showcase/undoredo/src/main/java/org/jrebirth/af/showcase/undoredo/ui/UndoView.java
+++ b/org.jrebirth.af/showcase/undoredo/src/main/java/org/jrebirth/af/showcase/undoredo/ui/UndoView.java
@@ -19,9 +19,8 @@ package org.jrebirth.af.showcase.undoredo.ui;
 
 import javafx.scene.control.Button;
 import javafx.scene.layout.BorderPane;
-import javafx.scene.layout.FlowPaneBuilder;
+import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.Pane;
-import javafx.scene.layout.PaneBuilder;
 
 import org.jrebirth.af.api.exception.CoreException;
 import org.jrebirth.af.core.ui.AbstractView;
@@ -81,11 +80,10 @@ public final class UndoView extends AbstractView<UndoModel, BorderPane, UndoCont
         this.addSquareButton = new Button("Add Square");
         this.addRectangleButton = new Button("Add Rectangle");
 
-        node().setTop(FlowPaneBuilder.create()
-                                     .children(this.undoButton, this.redoButton, this.addCircleButton, this.addSquareButton, this.addRectangleButton)
-                                     .build());
+        node().setTop(new FlowPane(this.undoButton, this.redoButton, this.addCircleButton, this.addSquareButton, this.addRectangleButton));
 
-        this.editor = PaneBuilder.create().style("-fx-background-color:beige").build();
+        this.editor = new Pane();
+        this.editor.setStyle("-fx-background-color:beige");
 
         node().setCenter(this.editor);
 

--- a/org.jrebirth.af/tooling/ecore2fx/pom.xml
+++ b/org.jrebirth.af/tooling/ecore2fx/pom.xml
@@ -17,25 +17,25 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>20.0</version>
+			<version>27.0.1-jre</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.common</artifactId>
-			<version>2.11.0-v20150805-0538</version>
+			<version>2.15.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.ecore</artifactId>
-			<version>2.11.1-v20150805-0538</version>
+			<version>2.15.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.ecore.xmi</artifactId>
-			<version>2.11.1-v20150805-0538</version>
+			<version>2.15.0</version>
 		</dependency>
 
 		<dependency>

--- a/org.jrebirth.af/tooling/jrebirth-maven-plugin/pom.xml
+++ b/org.jrebirth.af/tooling/jrebirth-maven-plugin/pom.xml
@@ -71,7 +71,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.5</version>
+				<version>3.6.0</version>
 				<configuration>
 					<goalPrefix>jrebirth</goalPrefix>
 					<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/org.jrebirth.af/transition/src/main/java/org/jrebirth/af/transition/command/slicer/NodeSlicerCommand.java
+++ b/org.jrebirth.af/transition/src/main/java/org/jrebirth/af/transition/command/slicer/NodeSlicerCommand.java
@@ -17,9 +17,6 @@
  */
 package org.jrebirth.af.transition.command.slicer;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleIntegerProperty;
@@ -28,10 +25,8 @@ import javafx.scene.Node;
 import javafx.scene.SnapshotParameters;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.image.ImageViewBuilder;
 import javafx.scene.image.WritableImage;
-import javafx.scene.shape.RectangleBuilder;
-
+import javafx.scene.shape.Rectangle;
 import org.jrebirth.af.api.wave.contract.WaveType;
 import org.jrebirth.af.core.service.DefaultService;
 import org.jrebirth.af.core.wave.WBuilder;
@@ -39,6 +34,9 @@ import org.jrebirth.af.core.wave.WaveBase;
 import org.jrebirth.af.transition.slicer.TransitionWaves;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The class <strong>ImageSlicerService</strong>.
@@ -255,20 +253,18 @@ public class NodeSlicerCommand extends DefaultService {
             for (double y = 0; y < height; y += getTileHeight()) {
 
                 // TODO OPTIMIZE
-                final ImageView iv = ImageViewBuilder
-                                                     .create()
-                                                     .image(getImage())
-                                                     .clip(RectangleBuilder.create()
-                                                                           .x(x)
-                                                                           .y(y)
-                                                                           .width(getTileWidth())
-                                                                           .height(getTileHeight())
-                                                                           .build())
-                                                     .opacity(1.0)
-                                                     .scaleX(0.9) // TODO
-                                                     .layoutX(x)
-                                                     .layoutY(y)
-                                                     .build();
+                final ImageView iv = new ImageView();
+                iv.setImage(getImage());
+                Rectangle rectangle = new Rectangle();
+                rectangle.setX(x);
+                rectangle.setY(y);
+                rectangle.setWidth(getTileWidth());
+                rectangle.setHeight(getTileHeight());
+                iv.setClip(rectangle);
+                iv.setOpacity(1.0);
+                iv.setScaleX(0.9); // TODO
+                iv.setLayoutX(x);
+                iv.setLayoutY(y);
 
                 this.slices.add(iv);
             }

--- a/org.jrebirth.af/transition/src/main/java/org/jrebirth/af/transition/slicer/RandomFadingService.java
+++ b/org.jrebirth.af/transition/src/main/java/org/jrebirth/af/transition/slicer/RandomFadingService.java
@@ -17,19 +17,17 @@
  */
 package org.jrebirth.af.transition.slicer;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
-import javafx.animation.TimelineBuilder;
 import javafx.beans.property.DoubleProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
-
 import org.jrebirth.af.core.service.DefaultService;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * The class <strong>ImageSlicerService</strong>.
@@ -120,9 +118,8 @@ public class RandomFadingService extends DefaultService {
             // }
         }
 
-        this.timeline = TimelineBuilder.create()
-                                       .keyFrames(keyFrames)
-                                       .build();
+        this.timeline = new Timeline();
+        this.timeline.getKeyFrames().setAll(keyFrames);
 
     }
 

--- a/org.jrebirth.af/transition/src/main/java/org/jrebirth/af/transition/slicer/SlidingDoorService.java
+++ b/org.jrebirth.af/transition/src/main/java/org/jrebirth/af/transition/slicer/SlidingDoorService.java
@@ -17,17 +17,7 @@
  */
 package org.jrebirth.af.transition.slicer;
 
-import java.util.List;
-import java.util.Random;
-
-import javafx.animation.Interpolator;
-import javafx.animation.ParallelTransition;
-import javafx.animation.ParallelTransitionBuilder;
-import javafx.animation.PauseTransition;
-import javafx.animation.PauseTransitionBuilder;
-import javafx.animation.SequentialTransitionBuilder;
-import javafx.animation.Transition;
-import javafx.animation.TranslateTransitionBuilder;
+import javafx.animation.*;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleIntegerProperty;
@@ -36,12 +26,14 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
 import javafx.util.Duration;
-
 import org.jrebirth.af.api.wave.contract.WaveType;
 import org.jrebirth.af.core.service.DefaultService;
 import org.jrebirth.af.core.wave.WBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Random;
 
 /**
  * The class <strong>ImageSlicerService</strong>.
@@ -206,8 +198,7 @@ public class SlidingDoorService extends DefaultService {
         // p.getChildren().add(RectangleBuilder.create().x(i * 40).y(0).width(40).height(600).fill(Color.AZURE).build());
         // }
 
-        final ParallelTransition parallel = ParallelTransitionBuilder.create()
-                                                                     .build();
+        final ParallelTransition parallel = new ParallelTransition();
 
         // // int i = 0;
         // // Collections.shuffle(nodes);
@@ -222,18 +213,15 @@ public class SlidingDoorService extends DefaultService {
 
         int i = 0;
         for (final Node node : this.nodes) {
-
-            parallel.getChildren().add(
-                                       TranslateTransitionBuilder.create()
-                                                                 .delay(Duration.millis(i * getNodeDelay()))
-                                                                 .node(node)
-                                                                 // .fromY(0)
-                                                                 // .toY(1000)
-                                                                 .byY(1000)
-                                                                 .duration(getTranslateDuration())
-                                                                 .interpolator(Interpolator.EASE_IN)
-                                                                 .build()
-                    );
+            TranslateTransition translateTransition = new TranslateTransition();
+            translateTransition.setDelay(Duration.millis(i * getNodeDelay()));
+            translateTransition.setNode(node);
+                    // .fromY(0)
+                    // .toY(1000)
+            translateTransition.setByY(1000);
+            translateTransition.setDuration(getTranslateDuration());
+            translateTransition.setInterpolator(Interpolator.EASE_IN);
+            parallel.getChildren().add(translateTransition);
             // parallel.getChildren().add(
             // TranslateTransitionBuilder.create()
             // .delay(getRandomDuration())
@@ -245,17 +233,13 @@ public class SlidingDoorService extends DefaultService {
             // );
             i++;
         }
-        final PauseTransition pt = PauseTransitionBuilder.create()
-                                                         .duration(Duration.seconds(1))
-                                                         .build();
+        final PauseTransition pt = new PauseTransition();
+        pt.setDuration(Duration.seconds(1));
 
-        this.fullTransition = SequentialTransitionBuilder.create()
-                                                         .children(
-                                                                   parallel
-                                                         )
-                                                         .autoReverse(true)
-                                                         .cycleCount(10)
-                                                         .build();
+        this.fullTransition = new SequentialTransition();
+        ((SequentialTransition) this.fullTransition).getChildren().setAll(parallel);
+        fullTransition.setAutoReverse(true);
+        fullTransition.setCycleCount(10);
 
     }
 

--- a/org.jrebirth.af/transition/src/test/java/SlideTransition.java
+++ b/org.jrebirth.af/transition/src/test/java/SlideTransition.java
@@ -15,26 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import java.io.InputStream;
-
 import javafx.animation.Interpolator;
 import javafx.animation.ParallelTransition;
-import javafx.animation.ParallelTransitionBuilder;
 import javafx.animation.TranslateTransition;
-import javafx.animation.TranslateTransitionBuilder;
 import javafx.application.Application;
 import javafx.event.EventHandler;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.effect.DropShadow;
-import javafx.scene.effect.DropShadowBuilder;
 import javafx.scene.image.Image;
-import javafx.scene.image.ImageViewBuilder;
+import javafx.scene.image.ImageView;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
-import javafx.scene.shape.RectangleBuilder;
+import javafx.scene.shape.Rectangle;
 import javafx.stage.Stage;
 import javafx.util.Duration;
+
+import java.io.InputStream;
 
 /**
  * The class <strong>JRebirthAnalyzer</strong>.
@@ -79,10 +76,9 @@ public final class SlideTransition extends Application {
         // RectangleBuilder.create().x(700).y(0).width(100).height(600).fill(Color.BEIGE).build()
         // );
 
-        final DropShadow shadow = DropShadowBuilder.create()
-                .radius(4)
-                .color(Color.GREY)
-                .build();
+        final DropShadow shadow = new DropShadow();
+                shadow.setRadius(4);
+                shadow.setColor(Color.GREY);
 
         Image image = null;
         final InputStream imageInputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("Properties.png");
@@ -91,28 +87,16 @@ public final class SlideTransition extends Application {
         }
 
         for (int i = 0; i < 40; i++) {
-            p.getChildren().add(
-                    ImageViewBuilder.create()
-                            .image(image)
-                            .clip(RectangleBuilder.create()
-                                    .x(i * 20)
-                                    .y(0)
-                                    .width(20)
-                                    .height(600)
-                                    .build())
-                            // RectangleBuilder.create()
-                            // .x(i * 40)
-                            // .y(0)
-                            // .fitWidth(40)
-                            // .fitHeight(600)
-                            // .width(40)
-                            // .height(600)
-                            // .fill(Color.AZURE)
-                            .effect(shadow)
-                            // .strokeDashArray(2.0, 4.0)
-                            // .stroke(Color.CHOCOLATE)
-                            .build()
-                    );
+            Rectangle rectangle = new Rectangle();
+            rectangle.setX(i * 20);
+            rectangle.setY(0);
+            rectangle.setWidth(20);
+            rectangle.setHeight(600);
+            ImageView imageView = new ImageView();
+            imageView.setImage(image);
+            imageView.setClip(rectangle);
+            imageView.setEffect(shadow);
+            p.getChildren().add(imageView);
         }
         stage.show();
 
@@ -125,21 +109,21 @@ public final class SlideTransition extends Application {
 
         };
 
-        final ParallelTransition st = ParallelTransitionBuilder.create().delay(Duration.seconds(1)).autoReverse(true).cycleCount(10).build();
+        final ParallelTransition st = new ParallelTransition();
+        st.setDelay(Duration.seconds(1));
+        st.setAutoReverse(true);
+        st.setCycleCount(10);
         int i = 0;
         for (final Node n : p.getChildren()) {
-
-            st.getChildren().add(
-                    TranslateTransitionBuilder.create()
-                            .delay(Duration.millis(i * 50))
-                            .node(n)
-                            .fromY(0)
-                            .toY(1000)
-                            .duration(Duration.millis(1000))
-                            .interpolator(Interpolator.EASE_IN)
-                            .onFinished(shadowRemover)
-                            .build()
-                    );
+            TranslateTransition translateTransition = new TranslateTransition();
+            translateTransition.setDelay(Duration.millis(i * 50));
+            translateTransition.setNode(n);
+            translateTransition.setFromY(0);
+            translateTransition.setToY(1000);
+            translateTransition.setDuration(Duration.millis(1000));
+            translateTransition.setInterpolator(Interpolator.EASE_IN);
+            translateTransition.setOnFinished(shadowRemover); ;
+            st.getChildren().add(translateTransition);
             i++;
         }
 


### PR DESCRIPTION
The latest version of JRebirth can not be used on a JVM version >= 9.

The goal of this PR is to make JRebirth compatible with JVM >= 9.