### PR TITLE
Add new configuration parameter: autoReleaseModels

### DIFF
--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/resource/provided/parameter/CoreParameters.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/resource/provided/parameter/CoreParameters.java
@@ -72,4 +72,8 @@ public interface CoreParameters {
      */
     ParameterItem<String> WAVE_HANDLER_PREFIX = create("waveHandlerPrefix", "DO_");
 
+    /**
+     * Determine if the models will be instantly released when its root node will be removed from its parent
+     */
+    ParameterItem<Boolean> AUTO_RELEASE_MODELS = create("autoReleaseModels", false);
 }

--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/ui/AbstractBaseModel.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/ui/AbstractBaseModel.java
@@ -30,7 +30,10 @@ import org.jrebirth.af.api.ui.annotation.CreateViewIntoJAT;
 import org.jrebirth.af.api.wave.Wave;
 import org.jrebirth.af.core.component.behavior.AbstractBehavioredComponent;
 import org.jrebirth.af.core.concurrent.JRebirth;
+import org.jrebirth.af.core.resource.provided.parameter.CoreParameters;
 import org.jrebirth.af.core.util.ClassUtility;
+
+import java.util.Optional;
 
 /**
  *
@@ -229,11 +232,13 @@ public abstract class AbstractBaseModel<M extends Model> extends AbstractBehavio
      */
     protected void attachParentListener() {
 
-        final AutoRelease ar = ClassUtility.getLastClassAnnotation(this.getClass(), AutoRelease.class);
+        final Optional<AutoRelease> autoReleaseAnnotation = Optional.ofNullable(ClassUtility.getLastClassAnnotation(this.getClass(), AutoRelease.class));
 
-        // Only manage automatic release when the annotation exists with true value
-        if (ar != null && ar.value() && node() != null) { // TODO check rootnode null when using NullView
+        // Use @AutoRelease if present, otherwise use check in core parameters (false by default)
+        boolean autoRelease = autoReleaseAnnotation.map(AutoRelease::value).orElseGet(CoreParameters.AUTO_RELEASE_MODELS::get);
+        autoRelease &= node() != null;
 
+        if (autoRelease) {
             // Allow to release the model if the root business object doesn't exist anymore
             node().parentProperty().addListener(new ChangeListener<Node>() {
 


### PR DESCRIPTION
Hi Seb,

Here is a simple pull request to configure the default value of autorelease on all models.
Default value is false as its coded now. If set to true all models will be considered as AutoRelease.
But if a @AutoRelease is added to a model, it will use the defined value, overriding the configuration for this model.