### PR TITLE
Status of undefined waves never change when there is no subscription

### DIFF
--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/link/NotifierBase.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/link/NotifierBase.java
@@ -275,14 +275,13 @@ public class NotifierBase extends AbstractGlobalReady implements Notifier, LinkM
             if (CoreParameters.DEVELOPER_MODE.get()) {
                 this.unprocessedWaveHandler.manageUnprocessedWave(NO_WAVE_LISTENER.getText(wave.waveType().toString()), wave);
             }
+
+            // Mark the wave as Handled when there is no subscription
+            if (!wave.isRelated()) {
+                LOGGER.info(NOTIFIER_HANDLES, wave.toString());
+                wave.status(Status.Handled);
+            }
         }
-
-        // The current wave will be marked as Handled when all Wave Handlers will be terminated
-        // if(!wave.isRelated()){
-        // LOGGER.info(NOTIFIER_HANDLES, wave.toString());
-        // wave.status(Status.Handled);
-        // }
-
     }
 
     /**


### PR DESCRIPTION
An undefined wave always keep its status as Consumed when there is no subscription to it :

> `this.notifierMap.containsKey(wave.waveType())` will be false

One of the consequence: pending task were never removed from services when the returned wave is not handle by someone.
Not sure if you would prefer having the wave to fail as behavior for this case so be free to let your comment.

