### PR TITLE
Fix ResourceBuilder item storage in multi-threaded context

### DIFF
--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/resource/builder/AbstractResourceBuilder.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/resource/builder/AbstractResourceBuilder.java
@@ -18,6 +18,7 @@
 package org.jrebirth.af.core.resource.builder;
 
 import java.lang.ref.SoftReference;
+import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
 
@@ -41,13 +42,13 @@ import org.jrebirth.af.core.resource.provided.parameter.CoreParameters;
 public abstract class AbstractResourceBuilder<I extends ResourceItem<?, ?, ?>, P extends ResourceParams, R> implements ResourceBuilder<I, P, R> {
 
     /** The resource weak Map. */
-    private final Map<I, P> paramsMap = new WeakHashMap<>();
+    private final Map<I, P> paramsMap = Collections.synchronizedMap(new WeakHashMap<>());
 
     /**
      * The resource weak Map.<br />
      * SoftReference can be kept longer in memory depending on the -client or -server jvm argument and on Xms and Xms values.
      */
-    protected final Map<String, SoftReference<R>> resourceMap = new WeakHashMap<>();
+    protected final Map<String, SoftReference<R>> resourceMap = Collections.synchronizedMap(new WeakHashMap<>());
 
     /**
      * {@inheritDoc}
@@ -93,7 +94,7 @@ public abstract class AbstractResourceBuilder<I extends ResourceItem<?, ?, ?>, P
         // Retrieve the resource weak reference from the map
         final SoftReference<R> resourceSoftRef = this.resourceMap.get(paramsKey);
 
-        // Warning the gc can collect gthe resource between the test and the getter call so we have to get the resource immediately
+        // Warning the gc can collect the resource between the test and the getter call so we have to get the resource immediately
         // and test it instead of testing the reference value
 
         // The resourceSoftRef may be null if nobody use it

--- a/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/resource/AbstractResourceBuilderTest.java
+++ b/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/resource/AbstractResourceBuilderTest.java
@@ -1,0 +1,50 @@
+package org.jrebirth.af.core.resource;
+
+import org.jrebirth.af.api.resource.color.ColorItem;
+import org.jrebirth.af.core.resource.builder.AbstractResourceBuilder;
+import org.jrebirth.af.core.resource.color.RGB255Color;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.jrebirth.af.core.resource.Resources.create;
+import static org.junit.Assert.assertEquals;
+
+public class AbstractResourceBuilderTest {
+
+    @Test
+    public void multiThreadedItemCreationTest() throws NoSuchFieldException, IllegalAccessException, InterruptedException {
+        ExecutorService service = Executors.newFixedThreadPool(5);
+
+        List<ColorItem> allItems = new CopyOnWriteArrayList<>();
+
+        List<Callable<Void>> tasks = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            tasks.add(() -> {
+                List<ColorItem> items = new ArrayList<>();
+                for (int j = 0; j < 1000; j++) {
+                    items.add(create(new RGB255Color(107, 69, 251)));
+                }
+                allItems.addAll(items);
+                return null;
+            });
+        }
+
+        // Invoke all tasks and wait for them to finish
+        service.invokeAll(tasks);
+
+        Field privateField = AbstractResourceBuilder.class.getDeclaredField("paramsMap");
+        privateField.setAccessible(true);
+        Map paramsMap = (Map) privateField.get(ResourceBuilders.COLOR_BUILDER);
+
+        assertEquals(5000, allItems.size());
+        assertEquals(5000, paramsMap.size());
+    }
+}


### PR DESCRIPTION
In multi-threaded context, resources loaded from different thread can provoke NPE or DeadLock.

Here are some exception we catch over the years:


> Caused by: java.lang.NullPointerException: null
> at org.jrebirth.af.core.resource.builder.AbstractResourceBuilder.get(AbstractResourceBuilder.java:91)
> at org.jrebirth.af.core.resource.builder.AbstractResourceBuilder.get(AbstractResourceBuilder.java:41)
> at org.jrebirth.af.api.resource.image.ImageItem.get(ImageItem.java:45)
> at com.dooapp.dsdk.core.action.DsdkActions$1.(DsdkActions.java:46)
> at com.dooapp.dsdk.core.action.DsdkActions.showHomeAction(DsdkActions.java:43)
> at com.dooapp.dsdk.core.ui.basicview.DsdkModel.doJcromInitialized(DsdkModel.java:218)
> ... 17 common frames omitted




> java.lang.NullPointerException: null
> at org.jrebirth.af.core.resource.builder.AbstractResourceBuilder.get(AbstractResourceBuilder.java:91)
> at org.jrebirth.af.core.resource.builder.AbstractResourceBuilder.get(AbstractResourceBuilder.java:41)
> at org.jrebirth.af.api.resource.image.ImageItem.get(ImageItem.java:45)
> at com.dooapp.plugin.q8721.section.PromeventProjectSectionProvider.createPromeventCommunityButton(PromeventProjectSectionProvider.java:424)
> at com.dooapp.plugin.q8721.section.PromeventProjectSectionProvider.decorate(PromeventProjectSectionProvider.java:417)



It's also probably the cause of https://github.com/JRebirth/JRebirth/issues/223