### PR TITLE
Fix styles resources builder

### DIFF
--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/util/ModuleUtility.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/util/ModuleUtility.java
@@ -17,15 +17,13 @@
  */
 package org.jrebirth.af.core.util;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.URL;
-import java.net.URLEncoder;
-
 import org.jrebirth.af.api.resource.ResourceItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
 
 /**
  * The class <strong>ClassUtility</strong>.
@@ -74,15 +72,9 @@ public final class ModuleUtility implements UtilMessages {
 
 	public static URL getResourceAsURL(Object object, String resourcePath, String resourceName) {
 		Module m = getModule(object);
-		String path = resourcePath + resourceName;
-		URL url = null;
-		try {
-			url = m.getClassLoader().getResource(URLEncoder.encode(path, "UTF-8"));
-			if (url == null) {
-				LOGGER.error("Resource : {} not found into module folder: {}", resourceName, resourcePath);
-			}
-		} catch (UnsupportedEncodingException e) {
-			LOGGER.error("Impossible to encode path " + path, e);
+		URL url = m.getClassLoader().getResource(resourcePath + resourceName);
+		if (url == null) {
+			LOGGER.error("Resource : {} not found into module folder: {}", resourceName, resourcePath);
 		}
 		return url;
 	}

--- a/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/resource/style/StyleTest.java
+++ b/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/resource/style/StyleTest.java
@@ -1,0 +1,12 @@
+package org.jrebirth.af.core.resource.style;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StyleTest {
+
+    @Test
+    public void loading() throws Exception {
+        Assert.assertNotNull(TestStyles.DEFAULT_CSS.get());
+    }
+}

--- a/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/resource/style/TestStyles.java
+++ b/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/resource/style/TestStyles.java
@@ -1,0 +1,14 @@
+package org.jrebirth.af.core.resource.style;
+
+import org.jrebirth.af.api.resource.style.StyleSheetItem;
+
+import static org.jrebirth.af.core.resource.Resources.create;
+
+public interface TestStyles {
+
+    /**************************************************************************************/
+    /** ________________________________Style Parameters.________________________________ */
+    /**************************************************************************************/
+
+    StyleSheetItem DEFAULT_CSS = create(new StyleSheet("default"));
+}


### PR DESCRIPTION
In branch 9x CSS styles are not loaded anymore (tested on Windows only).
This is cause of the path of the file that is now encoded: `styles/default.css` --> `styles%20default.css`

Not sure if it's the right way to change directly `getResourceAsURL`, but all unit tests pass.