### PR TITLE
Upgrade JAXB to latest version

### DIFF
--- a/org.jrebirth.af/pom.xml
+++ b/org.jrebirth.af/pom.xml
@@ -39,6 +39,10 @@
 		<surefire.version>2.18.1</surefire.version>
 		<slf4j.version>2.0.10</slf4j.version>
 
+		<jaxb.api.version>4.0.2</jaxb.api.version>
+		<jaxb.runtime.version>4.0.5</jaxb.runtime.version>
+		<jakarta.activation-api.version>2.1.3</jakarta.activation-api.version>
+		<jaxb.maven.plugin.version>4.0.3</jaxb.maven.plugin.version>
 	</properties>
 
 	<modules>

--- a/org.jrebirth.af/presentation/pom.xml
+++ b/org.jrebirth.af/presentation/pom.xml
@@ -13,10 +13,6 @@
 	<name>Prez Engine</name>
 	<description>Base files to build a JavaFX slide's presentation</description>
 
-	<properties>
-		<jaxb.version>2.3.1</jaxb.version>
-	</properties>
-
 	<build>
 		<plugins>
 
@@ -28,72 +24,65 @@
 				</configuration>
 			</plugin>
 
-
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>jaxb2-maven-plugin</artifactId>
-				<version>2.5.0</version>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
+				<version>${jaxb.maven.plugin.version}</version>
 				<executions>
 					<execution>
-						<id>xjc</id>
 						<goals>
-							<goal>xjc</goal>
+							<goal>generate</goal>
 						</goals>
+						<configuration>
+							<noFileHeader>true</noFileHeader>
+							<extension>true</extension>
+							<locale>en</locale>
+							<generatePackage>org.jrebirth.af.presentation.model</generatePackage>
+							<generateDirectory>target/generated-sources</generateDirectory>
+							<schemaDirectory>src/main/resources/presentation/</schemaDirectory>
+							<schemaIncludes>
+								<include>Presentation.xsd</include>
+							</schemaIncludes>
+							<plugins>
+								<plugin>
+									<groupId>org.jvnet.jaxb</groupId>
+									<artifactId>jaxb-plugins</artifactId>
+									<version>${jaxb.maven.plugin.version}</version>
+								</plugin>
+							</plugins>
+						</configuration>
 					</execution>
 				</executions>
-
-				<configuration>
-					<sources>
-						<source>src/main/resources/presentation/Presentation.xsd</source>
-					</sources>
-					<packageName>org.jrebirth.af.presentation.model</packageName>
-					<outputDirectory>target/generated-sources</outputDirectory>
-
-					<failOnNoSchemas>false</failOnNoSchemas>
-
-				</configuration>
-
-				<dependencies>
-					<dependency>
-						<groupId>javax.xml.bind</groupId>
-						<artifactId>jaxb-api</artifactId>
-						<version>${jaxb.version}</version>
-					</dependency>
-					<dependency>
-						<groupId>org.glassfish.jaxb</groupId>
-						<artifactId>jaxb-runtime</artifactId>
-						<version>${jaxb.version}</version>
-					</dependency>
-				</dependencies>
 			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
 		<dependency>
 			<groupId>org.openjfx</groupId>
 			<artifactId>javafx-web</artifactId>
 			<version>${openjfx.version}</version>
 		</dependency>
-
 		<dependency>
-			<groupId>javax.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
-			<version>${jaxb.version}</version>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>${jaxb.api.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-runtime</artifactId>
-			<version>${jaxb.version}</version>
+			<version>${jaxb.runtime.version}</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.jvnet.jaxb</groupId>
+			<artifactId>jaxb-plugins-runtime</artifactId>
+			<version>${jaxb.maven.plugin.version}</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/org.jrebirth.af/presentation/src/main/java/module-info.java
+++ b/org.jrebirth.af/presentation/src/main/java/module-info.java
@@ -10,7 +10,7 @@ open module org.jrebirth.af.presentation {
 	requires org.jrebirth.af.api;
     requires org.jrebirth.af.core;
 
-    requires java.xml.bind;
+    requires jakarta.xml.bind;
     
     requires org.slf4j;
 

--- a/org.jrebirth.af/presentation/src/main/java/org/jrebirth/af/presentation/service/PresentationService.java
+++ b/org.jrebirth.af/presentation/src/main/java/org/jrebirth/af/presentation/service/PresentationService.java
@@ -17,25 +17,23 @@
  */
 package org.jrebirth.af.presentation.service;
 
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
-import javax.xml.stream.FactoryConfigurationError;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
-
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import org.jrebirth.af.core.service.DefaultService;
 import org.jrebirth.af.presentation.model.Presentation;
 import org.jrebirth.af.presentation.model.Slide;
 import org.jrebirth.af.presentation.resources.PrezParameters;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.xml.stream.FactoryConfigurationError;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 /**
  * The class <strong>PresentationService</strong>.

--- a/org.jrebirth.af/rest/pom.xml
+++ b/org.jrebirth.af/rest/pom.xml
@@ -10,11 +10,6 @@
 	<name>Rest Services</name>
 	<description>Provides base classes for calling remote rest services</description>
 
-	<properties>
-		<jaxb.api.version>2.3.2</jaxb.api.version>
-		<jaxb.impl.version>2.3.2</jaxb.impl.version>
-		<activation.api.version>1.2.1</activation.api.version>
-	</properties>
 	<build>
 		<plugins>
 
@@ -56,7 +51,7 @@
 		<dependency>
 			<groupId>jakarta.ws.rs</groupId>
 			<artifactId>jakarta.ws.rs-api</artifactId>
-			<version>2.1.5</version>
+			<version>3.1.0</version>
 		</dependency>
 
 		<dependency>
@@ -68,7 +63,7 @@
 		<dependency>
 			<groupId>jakarta.activation</groupId>
 			<artifactId>jakarta.activation-api</artifactId>
-			<version>${activation.api.version}</version>
+			<version>${jakarta.activation-api.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/org.jrebirth.af/rest/src/main/java/module-info.java
+++ b/org.jrebirth.af/rest/src/main/java/module-info.java
@@ -12,7 +12,7 @@ module org.jrebirth.af.rest {
     opens org.jrebirth.af.rest.service to org.jrebirth.af.core;
     opens org.jrebirth.af.rest.service.impl to org.jrebirth.af.core;
 
-    requires java.ws.rs;
+    requires jakarta.ws.rs;
     requires javafx.base;
     requires org.jrebirth.af.api;
     requires org.jrebirth.af.core;

--- a/org.jrebirth.af/rest/src/main/java/org/jrebirth/af/rest/service/ClientProviderService.java
+++ b/org.jrebirth.af/rest/src/main/java/org/jrebirth/af/rest/service/ClientProviderService.java
@@ -1,7 +1,6 @@
 package org.jrebirth.af.rest.service;
 
-import javax.ws.rs.client.Client;
-
+import jakarta.ws.rs.client.Client;
 import org.jrebirth.af.api.module.RegistrationPoint;
 import org.jrebirth.af.api.service.Service;
 

--- a/org.jrebirth.af/rest/src/main/java/org/jrebirth/af/rest/service/impl/AbstractCRUDRestService.java
+++ b/org.jrebirth.af/rest/src/main/java/org/jrebirth/af/rest/service/impl/AbstractCRUDRestService.java
@@ -1,20 +1,17 @@
 package org.jrebirth.af.rest.service.impl;
 
-import java.util.List;
-
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.jrebirth.af.api.wave.Wave;
 import org.jrebirth.af.api.wave.contract.WaveType;
 import org.jrebirth.af.core.wave.JRebirthItems;
 import org.jrebirth.af.core.wave.WBuilder;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 public class AbstractCRUDRestService<O extends Object> extends AbstractRestService implements CRUDRestService<O> {
 
@@ -62,7 +59,7 @@ public class AbstractCRUDRestService<O extends Object> extends AbstractRestServi
                                                        .request(MediaType.APPLICATION_XML)
                                                        .post(Entity.xml(object));
 
-        return updateResponse.getStatusInfo() == Status.OK;
+        return updateResponse.getStatusInfo() == Response.Status.OK;
     }
 
     /**
@@ -75,7 +72,7 @@ public class AbstractCRUDRestService<O extends Object> extends AbstractRestServi
                                                        .request(MediaType.APPLICATION_XML)
                                                        .put(Entity.xml(object));
 
-        return updateResponse.getStatusInfo() == Status.OK;
+        return updateResponse.getStatusInfo() == Response.Status.OK;
     }
 
     /**
@@ -90,7 +87,7 @@ public class AbstractCRUDRestService<O extends Object> extends AbstractRestServi
                                                        .request(MediaType.APPLICATION_XML)
                                                        .delete();
 
-        return deleteResponse.getStatusInfo() == Status.OK;
+        return deleteResponse.getStatusInfo() == Response.Status.OK;
     }
 
     /**

--- a/org.jrebirth.af/rest/src/main/java/org/jrebirth/af/rest/service/impl/AbstractRestService.java
+++ b/org.jrebirth.af/rest/src/main/java/org/jrebirth/af/rest/service/impl/AbstractRestService.java
@@ -1,7 +1,6 @@
 package org.jrebirth.af.rest.service.impl;
 
-import javax.ws.rs.client.WebTarget;
-
+import jakarta.ws.rs.client.WebTarget;
 import org.jrebirth.af.api.annotation.Link;
 import org.jrebirth.af.api.wave.Wave;
 import org.jrebirth.af.core.service.AbstractService;

--- a/org.jrebirth.af/rest/src/main/java/org/jrebirth/af/rest/service/impl/SimpleClientProviderService.java
+++ b/org.jrebirth.af/rest/src/main/java/org/jrebirth/af/rest/service/impl/SimpleClientProviderService.java
@@ -1,8 +1,7 @@
 package org.jrebirth.af.rest.service.impl;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
 import org.jrebirth.af.api.annotation.OnRelease;
 import org.jrebirth.af.api.module.Register;
 import org.jrebirth.af.api.wave.Wave;


### PR DESCRIPTION
Bump JAXB to latest version: 
- api to 4.0.2
- runtime to 4.0.5
- jaxb-maven-plugin 4.0.3 (the most up-to-date project is https://github.com/highsource/jaxb-tools)

The main differences are package renaming