### PR TITLE
Use ClasspathUtility.loadInputStream with unamed module + open jrebirth.properties in Sample

### DIFF
--- a/org.jrebirth.af/core/pom.xml
+++ b/org.jrebirth.af/core/pom.xml
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>io.github.classgraph</groupId>
 			<artifactId>classgraph</artifactId>
-			<version>4.8.12</version>
+			<version>4.8.168</version>
 		</dependency>
 
 		<!-- Dependency used at compile time to manage Java Webstart classpath scan If this jar is not available the related code will not be called -->

--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/util/ClasspathUtility.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/util/ClasspathUtility.java
@@ -17,6 +17,11 @@
  */
 package org.jrebirth.af.core.util;
 
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ScanResult;
+import org.jrebirth.af.api.log.JRLogger;
+import org.jrebirth.af.core.log.JRLoggerFactory;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -26,12 +31,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
-
-import org.jrebirth.af.api.log.JRLogger;
-import org.jrebirth.af.core.log.JRLoggerFactory;
-
-import io.github.classgraph.ClassGraph;
-import io.github.classgraph.ScanResult;
 
 /**
  * The class <strong>ClassUtility</strong>.
@@ -72,8 +71,7 @@ public final class ClasspathUtility implements UtilMessages {
 
         final List<String> resources = new ArrayList<>();
 
-        try (ScanResult scanResult = new ClassGraph()
-                                                     .whitelistPaths("/").scan()) {
+        try (ScanResult scanResult = new ClassGraph().acceptPaths("/").scan()) {
             resources.addAll(scanResult.getResourcesMatchingPattern(searchPattern).asMap().keySet());
         }
         // Sort resources
@@ -83,7 +81,7 @@ public final class ClasspathUtility implements UtilMessages {
     }
 
     /**
-     * TRy to load a custom resource file.
+     * Try to load a custom resource file.
      *
      * @param custConfFileName the custom resource file to load
      *
@@ -91,11 +89,9 @@ public final class ClasspathUtility implements UtilMessages {
      */
     public static InputStream loadInputStream(final String custConfFileName) {
         InputStream is = null;
-        
-        ClassLoader cl = ModuleLayer.boot().findLoader("org.jrebirth.af.core");
-        
+
         final File resourceFile = new File(custConfFileName);
-        // Check if the file could be find
+        // Check if the file can be found
         if (resourceFile.exists()) {
             try {
                 is = new FileInputStream(resourceFile);
@@ -104,7 +100,7 @@ public final class ClasspathUtility implements UtilMessages {
             }
         } else {
             // Otherwise try to load from context classloader
-            is = cl.getResourceAsStream(custConfFileName);
+            is = Thread.currentThread().getContextClassLoader().getResourceAsStream(custConfFileName);
         }
 
         return is;

--- a/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/application/NullApplicationConfigurationTest.java
+++ b/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/application/NullApplicationConfigurationTest.java
@@ -24,8 +24,8 @@ public class NullApplicationConfigurationTest extends JRebirthApplicationTest<Nu
     public void checkNullConf() {
 
         // Check that default value is used not those of properties file
-        Assert.assertEquals(new Integer(800), StageParameters.APPLICATION_SCENE_WIDTH.get());
-        Assert.assertEquals(new Integer(600), StageParameters.APPLICATION_SCENE_HEIGHT.get());
+        Assert.assertEquals(Integer.valueOf(800), StageParameters.APPLICATION_SCENE_WIDTH.get());
+        Assert.assertEquals(Integer.valueOf(600), StageParameters.APPLICATION_SCENE_HEIGHT.get());
 
     }
 

--- a/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/application/apps/FullConfApplication.java
+++ b/org.jrebirth.af/core/src/test/java/org/jrebirth/af/core/application/apps/FullConfApplication.java
@@ -12,7 +12,6 @@ import org.jrebirth.af.core.application.DefaultApplication;
  * @author Sébastien Bordes
  */
 @Configuration(value = ".*-jrebirth", extension = "properties", schedule = 60)
-// @Configuration
 public class FullConfApplication extends DefaultApplication<Pane> {
 
     /**

--- a/org.jrebirth.af/sample/src/main/java/module-info.java
+++ b/org.jrebirth.af/sample/src/main/java/module-info.java
@@ -11,6 +11,7 @@ module org.jrebirth.af.sample {
     exports org.jrebirth.af.sample.resources;
     exports org.jrebirth.af.sample.service;
 
+    opens org.jrebirth.af.sample;
     opens org.jrebirth.af.sample.styles;
     opens org.jrebirth.af.sample.fonts;
 


### PR DESCRIPTION
Hi Sébastien,

Two main fixes here: 
- open org.jrebirth.af.sample in Sample to access jrebirth.properties
- reuse Thread.currentThread().getContextClassLoader() in classpathUtility to be compliant with no-modular projects