### PR TITLE
Manage static fields in processFields method

### DIFF
--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/ui/AbstractView.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/ui/AbstractView.java
@@ -47,6 +47,7 @@ import org.jrebirth.af.core.util.ClassUtility;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 
 /**
  *
@@ -240,7 +241,7 @@ public abstract class AbstractView<M extends Model, N extends Node, C extends Co
                 // If a property was private, it must set to accessible = false after processing action
                 boolean needToHide = false;
                 // For private properties, set them accessible temporary
-                if (!f.canAccess(this)) {
+                if (!f.canAccess(Modifier.isStatic(f.getModifiers()) ? null : this)) {
                     f.setAccessible(true);
                     needToHide = true;
                 }
@@ -248,7 +249,7 @@ public abstract class AbstractView<M extends Model, N extends Node, C extends Co
                 processAnnotations(f);
 
                 // Reset the property visibility
-                if (needToHide && f.canAccess(this)) {
+                if (needToHide && f.canAccess(Modifier.isStatic(f.getModifiers()) ? null : this)) {
                     f.setAccessible(false);
                 }
             }


### PR DESCRIPTION
Hi Sébastien,

From Java 9+ isAccessible() has been replaced by canAccess(). As described in the documentation for static fields it must be call with null argument, otherwise it would result with this error: 

```java
java.lang.IllegalArgumentException: non-null object for private static final javafx.scene.image.ImageView com.dooapp.dsdk.core.ui.help.AssistanceView.resources
	at java.base/java.lang.reflect.AccessibleObject.canAccess(Unknown Source)
	at org.jrebirth.af.core.ui.AbstractView.processFields(AbstractView.java:243)
	at org.jrebirth.af.core.ui.AbstractView.prepare(AbstractView.java:165)
	at org.jrebirth.af.core.ui.AbstractModel.prepareView(AbstractModel.java:64)
	at org.jrebirth.af.core.concurrent.JRebirth.run(JRebirth.java:98)
	at org.jrebirth.af.core.ui.AbstractBaseModel.ready(AbstractBaseModel.java:79)
	at org.jrebirth.af.core.component.basic.AbstractComponent.setup(AbstractComponent.java:526)
	at org.jrebirth.af.core.facade.AbstractFacade.retrieveMany(AbstractFacade.java:224)
	at org.jrebirth.af.core.facade.AbstractFacade.retrieve(AbstractFacade.java:186)
	at org.jrebirth.af.core.command.basic.showmodel.PrepareModelCommand.perform(PrepareModelCommand.java:62)
	at org.jrebirth.af.core.command.AbstractBaseCommand.innerRun(AbstractBaseCommand.java:205)
	at org.jrebirth.af.core.command.CommandRunnable.runInto(CommandRunnable.java:67)
	at org.jrebirth.af.core.concurrent.AbstractJrbRunnable.run(AbstractJrbRunnable.java:80)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)`
```

So this fix verify if the field is static or not to send the right argument.