### PR TITLE
Add more scene customization at initialization

### DIFF
--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/application/AbstractApplication.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/application/AbstractApplication.java
@@ -17,14 +17,15 @@
  */
 package org.jrebirth.af.core.application;
 
-import java.io.File;
-import java.lang.Thread.UncaughtExceptionHandler;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.ServiceLoader;
-import java.util.stream.Collectors;
-
+import javafx.application.Application;
+import javafx.application.Preloader;
+import javafx.application.Preloader.ProgressNotification;
+import javafx.scene.Scene;
+import javafx.scene.image.Image;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.Pane;
+import javafx.stage.Stage;
 import org.jrebirth.af.api.application.Configuration;
 import org.jrebirth.af.api.application.JRebirthApplication;
 import org.jrebirth.af.api.application.Localized;
@@ -44,7 +45,6 @@ import org.jrebirth.af.core.exception.handler.PoolUncaughtExceptionHandler;
 import org.jrebirth.af.core.log.JRLoggerFactory;
 import org.jrebirth.af.core.resource.ResourceBuilders;
 import org.jrebirth.af.core.resource.Resources;
-import org.jrebirth.af.core.resource.parameter.ParameterMessages;
 import org.jrebirth.af.core.resource.provided.JRebirthColors;
 import org.jrebirth.af.core.resource.provided.JRebirthStyles;
 import org.jrebirth.af.core.resource.provided.parameter.CoreParameters;
@@ -54,16 +54,13 @@ import org.jrebirth.af.core.util.ClassUtility;
 import org.jrebirth.af.core.util.ModuleUtility;
 import org.jrebirth.af.preloader.JRebirthPreloader;
 
-import javafx.application.Application;
-import javafx.application.Preloader;
-import javafx.application.Preloader.ProgressNotification;
-import javafx.scene.Scene;
-import javafx.scene.SceneAntialiasing;
-import javafx.scene.image.Image;
-import javafx.scene.input.KeyCode;
-import javafx.scene.input.KeyEvent;
-import javafx.scene.layout.Pane;
-import javafx.stage.Stage;
+import java.io.File;
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
 
 //import com.sun.javafx.application.LauncherImpl;
 
@@ -575,8 +572,13 @@ public abstract class AbstractApplication<P extends Pane> extends Application
 	 */
 	protected final Scene buildScene() throws CoreException {
 
-		final Scene scene = new Scene(buildRootPane(), StageParameters.APPLICATION_SCENE_WIDTH.get(),
-				StageParameters.APPLICATION_SCENE_HEIGHT.get(), true, SceneAntialiasing.BALANCED);
+		final Scene scene = new Scene(
+				buildRootPane(),
+				StageParameters.APPLICATION_SCENE_WIDTH.get(),
+				StageParameters.APPLICATION_SCENE_HEIGHT.get(),
+				StageParameters.APPLICATION_DEPTH_BUFFER.get(),
+				StageParameters.APPLICATION_SCENE_ANTIALIASING.get()
+		);
 		scene.setFill(JRebirthColors.SCENE_BG_COLOR.get());
 
 		return scene;

--- a/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/resource/provided/parameter/StageParameters.java
+++ b/org.jrebirth.af/core/src/main/java/org/jrebirth/af/core/resource/provided/parameter/StageParameters.java
@@ -17,17 +17,16 @@
  */
 package org.jrebirth.af.core.resource.provided.parameter;
 
-import static org.jrebirth.af.core.resource.Resources.create;
+import javafx.scene.SceneAntialiasing;
+import org.jrebirth.af.api.resource.image.ImageParams;
+import org.jrebirth.af.api.resource.parameter.ParameterItem;
+import org.jrebirth.af.core.resource.color.WebColor;
+import org.jrebirth.af.core.resource.provided.ResourcesImages;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.jrebirth.af.api.resource.image.ImageParams;
-//import org.jrebirth.af.api.resource.image.ImageParams;
-import org.jrebirth.af.api.resource.parameter.ParameterItem;
-import org.jrebirth.af.core.resource.color.WebColor;
-import org.jrebirth.af.core.resource.provided.JRebirthImages;
-import org.jrebirth.af.core.resource.provided.ResourcesImages;
+import static org.jrebirth.af.core.resource.Resources.create;
 
 /**
  * The class <strong>StageParameters</strong>.
@@ -69,6 +68,12 @@ public interface StageParameters {
 
     /** The application scene height. */
     ParameterItem<Integer> APPLICATION_SCENE_HEIGHT = create("applicationSceneHeight", 600);
+
+    /** The application scene depth buffer. */
+    ParameterItem<Boolean> APPLICATION_DEPTH_BUFFER = create("applicationDepthBuffer", false);
+
+    /** The application scene antialiasing. */
+    ParameterItem<SceneAntialiasing> APPLICATION_SCENE_ANTIALIASING = create("applicationSceneAntialiasing", SceneAntialiasing.DISABLED);
 
     /** The application scene background color. */
     ParameterItem<WebColor> APPLICATION_SCENE_BG_COLOR = create("applicationSceneBgColor", new WebColor("000000", 0.0));


### PR DESCRIPTION
Hi Sébastien,

Here is an improvement to customize two additional parameters when the Scene is build: DepthBuffer and SceneAntialiasing.

By default, in a basic 2D JavaFX app, depthBuffer is false and antialiasing is disabled.
There are useful to set them only when working in a 3D environment.

We need these modification after seeing some bugs in few customers:

- we notice that some JavaFX controls cannot be triggered on mouse click. With depthBuffer activated all 2D are computed just like if they were in a 3D environment. It's really complex to reproduce in a brand new project because it depends of the size of the scene, the resolution of the computer, the zoom, and the layout and bounds of nodes in the hierarchy. But we found the problem in our software and notice it was not necessary to activate this option. So we would be able to change it.

- we measure that the performance of the software is much more efficient with the default values. That is because many operations in the scene rendering are skipped. We have no problem on mac anymore.


So this PR allows to customize the value of these two parameters.
And I changed the default values with JavaFX default, which should be needed in 99% of JavaFX projects.