### PR TITLE
JPMS: remove redundant requires from module descriptors

### DIFF
--- a/org.jrebirth.af/component/src/main/java/module-info.java
+++ b/org.jrebirth.af/component/src/main/java/module-info.java
@@ -30,7 +30,6 @@ module org.jrebirth.af.component {
     requires javafx.base;
     requires javafx.controls;
     requires javafx.graphics;
-    requires org.jrebirth.af.api;
     requires org.jrebirth.af.preloader;
     requires org.jrebirth.af.core;
     

--- a/org.jrebirth.af/dialog/src/main/java/module-info.java
+++ b/org.jrebirth.af/dialog/src/main/java/module-info.java
@@ -8,7 +8,6 @@ module org.jrebirth.af.dialog {
     exports org.jrebirth.af.dialog.simpledialog;
     exports org.jrebirth.af.dialog.basic;
 
-	requires org.jrebirth.af.api;
     requires org.jrebirth.af.core;
 
     requires javafx.controls;

--- a/org.jrebirth.af/fxform/src/main/java/module-info.java
+++ b/org.jrebirth.af/fxform/src/main/java/module-info.java
@@ -10,7 +10,6 @@ module org.jrebirth.af.fxform {
     requires javafx.controls;
     requires javafx.graphics;
 
-    requires org.jrebirth.af.api;
     requires org.jrebirth.af.core;
 
     requires org.slf4j;

--- a/org.jrebirth.af/processor/src/main/java/module-info.java
+++ b/org.jrebirth.af/processor/src/main/java/module-info.java
@@ -11,7 +11,6 @@ module org.jrebirth.af.processor {
     requires transitive maven.model;
     requires transitive plexus.utils;
 
-    requires transitive org.jrebirth.af.api;
     requires transitive org.jrebirth.af.core;
     requires roaster.api;
     //requires roaster.jdt;

--- a/org.jrebirth.af/rest/src/main/java/module-info.java
+++ b/org.jrebirth.af/rest/src/main/java/module-info.java
@@ -14,7 +14,6 @@ module org.jrebirth.af.rest {
 
     requires java.ws.rs;
     requires javafx.base;
-    requires org.jrebirth.af.api;
     requires org.jrebirth.af.core;
     requires org.slf4j;
     

--- a/org.jrebirth.af/security/src/main/java/module-info.java
+++ b/org.jrebirth.af/security/src/main/java/module-info.java
@@ -10,6 +10,5 @@ module org.jrebirth.af.security {
     exports org.jrebirth.af.security.service;
     exports org.jrebirth.af.security.behavior;
 
-    requires org.jrebirth.af.api;
     requires org.jrebirth.af.core;
 }

--- a/org.jrebirth.af/showcase/demo/src/main/java/module-info.java
+++ b/org.jrebirth.af/showcase/demo/src/main/java/module-info.java
@@ -12,7 +12,6 @@ open module org.jrebirth.af.showcase.demo {
     requires javafx.controls;
     requires javafx.graphics;
     
-    requires org.jrebirth.af.api;
     requires org.jrebirth.af.component;
     requires org.jrebirth.af.core;
     

--- a/org.jrebirth.af/showcase/fonticon/src/main/java/module-info.java
+++ b/org.jrebirth.af/showcase/fonticon/src/main/java/module-info.java
@@ -21,7 +21,6 @@ module org.jrebirth.af.showcase.fonticon {
     requires javafx.base;
     requires javafx.controls;
     requires javafx.graphics;
-    requires org.jrebirth.af.api;
     requires org.jrebirth.af.core;
 
 }

--- a/org.jrebirth.af/showcase/workbench/src/main/java/module-info.java
+++ b/org.jrebirth.af/showcase/workbench/src/main/java/module-info.java
@@ -14,7 +14,6 @@ open module org.jrebirth.af.showcase.workbench {
 	requires javafx.base;
 	requires javafx.graphics;
 	
-	requires org.jrebirth.af.api;
 	requires org.jrebirth.af.component;
 	requires org.jrebirth.af.core;
 }

--- a/org.jrebirth.af/transition/src/main/java/module-info.java
+++ b/org.jrebirth.af/transition/src/main/java/module-info.java
@@ -7,7 +7,6 @@ module org.jrebirth.af.transition {
     exports org.jrebirth.af.transition.command.slicer;
     exports org.jrebirth.af.transition.slicer;
 
-	requires org.jrebirth.af.api;
     requires org.jrebirth.af.core;
 
     requires javafx.base;

--- a/org.jrebirth.af/undoredo/src/main/java/module-info.java
+++ b/org.jrebirth.af/undoredo/src/main/java/module-info.java
@@ -9,6 +9,5 @@ module org.jrebirth.af.undoredo {
     //exports org.jrebirth.af.undoredo;
 
     requires javafx.base;
-    requires org.jrebirth.af.api;
     requires org.jrebirth.af.core;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove redundant `requires org.jrebirth.af.api` entries from 11 `module-info.java` files where `org.jrebirth.af.core` is already required
- remove redundant `requires transitive org.jrebirth.af.api` in `processor` because `org.jrebirth.af.core` is already required transitively
- keep behavior unchanged while reducing module graph noise and descriptor maintenance overhead

## Validation
- `mvn -DskipTests -DcompilerArgument=-proc:none -pl component,undoredo,transition,fxform,showcase/fonticon,showcase/workbench,showcase/demo,processor compile`
- `mvn -DskipTests -DcompilerArgument=-proc:none -pl rest -am compile`

## Notes
- full reactor compile still fails in `security`/`dialog` due to an existing annotation processing classloading issue (`NoClassDefFoundError: org/jrebirth/af/api/annotation/Preload`) unrelated to this descriptor cleanup.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14d29bc7-89c8-4f16-b1b4-81d24b521744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14d29bc7-89c8-4f16-b1b4-81d24b521744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

