### PR TITLE
Migrate JavaFX dependencies to 26 and bump JRebirth to 12.0.0-SNAPSHOT

### DIFF
--- a/org.jrebirth.af/api/pom.xml
+++ b/org.jrebirth.af/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jrebirth.af</groupId>

--- a/org.jrebirth.af/archetype/pom.xml
+++ b/org.jrebirth.af/archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/org.jrebirth.af/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/org.jrebirth.af/archetype/src/main/resources/archetype-resources/pom.xml
@@ -83,7 +83,7 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.8.0</version>
 					<configuration>
-						<release>11</release>
+						<release>24</release>
 						<encoding>UTF-8</encoding>
 					</configuration>
 				</plugin>
@@ -96,7 +96,7 @@
 					<configuration>
 						<archive>
 							<manifestEntries>
-								<JavaFX-Version>2.0</JavaFX-Version>
+								<JavaFX-Version>26</JavaFX-Version>
 								<Main-Class>${appClass}</Main-Class>
 								<JavaFX-Application-Class>${appClass}</JavaFX-Application-Class>
 							</manifestEntries>
@@ -233,13 +233,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>preloader</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/org.jrebirth.af/component/.factorypath
+++ b/org.jrebirth.af/component/.factorypath
@@ -1,3 +1,3 @@
 <factorypath>
-    <factorypathentry kind="EXTJAR" id="C:\JREBIRTH\CACHE\GIT\JRebirth\org.jrebirth.af\processor\target\JRebirth-AnnotationProcessor-11.0.0-SNAPSHOT-4ide.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="EXTJAR" id="C:\JREBIRTH\CACHE\GIT\JRebirth\org.jrebirth.af\processor\target\JRebirth-AnnotationProcessor-12.0.0-SNAPSHOT-4ide.jar" enabled="true" runInBatchMode="false"/>
 </factorypath>

--- a/org.jrebirth.af/component/pom.xml
+++ b/org.jrebirth.af/component/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -31,7 +31,7 @@
 						<path>
 							<groupId>org.jrebirth.af</groupId>
 							<artifactId>processor</artifactId>
-							<version>11.0.0-SNAPSHOT</version>
+							<version>12.0.0-SNAPSHOT</version>
 							<classifier>4ide</classifier>
 						</path>
 					</annotationProcessorPaths>
@@ -51,20 +51,20 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>api</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<classifier>4ide</classifier>
 			<optional>true</optional>
 		</dependency>
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>preloader</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<classifier>tests</classifier>
 			<scope>test</scope>
 		</dependency>

--- a/org.jrebirth.af/core/pom.xml
+++ b/org.jrebirth.af/core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -25,13 +25,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>api</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>preloader</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>resources</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/org.jrebirth.af/dialog/pom.xml
+++ b/org.jrebirth.af/dialog/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jrebirth.af</groupId>
@@ -25,13 +25,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<classifier>4ide</classifier>
 			<optional>true</optional>
 		</dependency>

--- a/org.jrebirth.af/distribution/pom.xml
+++ b/org.jrebirth.af/distribution/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/org.jrebirth.af/form/pom.xml
+++ b/org.jrebirth.af/form/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org</groupId>
 		<artifactId>jrebirth</artifactId>
-		<version>0.8.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jrebirth</groupId>
 	<artifactId>form</artifactId>
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>org.jrebirth</groupId>
 			<artifactId>core</artifactId>
-			<version>0.8.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/org.jrebirth.af/fxform/pom.xml
+++ b/org.jrebirth.af/fxform/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -20,13 +20,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>api</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/org.jrebirth.af/iconfont-bridge/525icons/pom.xml
+++ b/org.jrebirth.af/iconfont-bridge/525icons/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>iconfont-bridge</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/org.jrebirth.af/iconfont-bridge/emojione/pom.xml
+++ b/org.jrebirth.af/iconfont-bridge/emojione/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>iconfont-bridge</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/org.jrebirth.af/iconfont-bridge/fontawesome/pom.xml
+++ b/org.jrebirth.af/iconfont-bridge/fontawesome/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>iconfont-bridge</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/org.jrebirth.af/iconfont-bridge/pom.xml
+++ b/org.jrebirth.af/iconfont-bridge/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>af</artifactId>
 		<groupId>org.jrebirth</groupId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -35,7 +35,7 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.8.0</version>
 					<configuration>
-						<release>11</release>
+						<release>24</release>
 						<encoding>UTF-8</encoding>
 					</configuration>
 				</plugin>
@@ -69,13 +69,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 		
 <!-- 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<classifier>tests</classifier>
 			<scope>test</scope>
 		</dependency> -->

--- a/org.jrebirth.af/iconfont-bridge/typicons/pom.xml
+++ b/org.jrebirth.af/iconfont-bridge/typicons/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>iconfont-bridge</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/org.jrebirth.af/iconfont-bridge/weathericons/pom.xml
+++ b/org.jrebirth.af/iconfont-bridge/weathericons/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>iconfont-bridge</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/org.jrebirth.af/pom.xml
+++ b/org.jrebirth.af/pom.xml
@@ -6,7 +6,8 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>organization</artifactId>
-		<version>2.1.1</version>
+		<version>12.0.0-SNAPSHOT</version>
+		<relativePath>../org.jrebirth/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>af</artifactId>
@@ -34,6 +35,7 @@
 		<surefire.version>2.18.1</surefire.version>
 		<slf4j.version>1.8.0-beta4</slf4j.version>
 		<openjfx.version>26</openjfx.version>
+		<java.version>24</java.version>
 
 	</properties>
 
@@ -177,11 +179,32 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
 				<configuration>
-					<source>24</source>
-					<target>24</target>
-					<release>24</release>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+					<release>${java.version}</release>
 				</configuration>
 				<!-- <dependencies> <dependency> <groupId>org.ow2.asm</groupId> <artifactId>asm</artifactId> <version>6.2</version> Use newer version of ASM </dependency> </dependencies> -->
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.5.0</version>
+				<executions>
+					<execution>
+						<id>enforce-java-24</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireJavaVersion>
+									<version>[24,)</version>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 
 			<!-- <plugin> <groupId>org.apache.maven.plugins</groupId> <artifactId>maven-project-info-reports-plugin</artifactId> <version>2.7</version> <dependencies> <dependency> <groupId>org.apache.maven.shared</groupId> 

--- a/org.jrebirth.af/pom.xml
+++ b/org.jrebirth.af/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>af</artifactId>
-	<version>11.0.0-SNAPSHOT</version>
+	<version>12.0.0-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<name>JRebirth Application Framework</name>
@@ -33,7 +33,7 @@
 
 		<surefire.version>2.18.1</surefire.version>
 		<slf4j.version>1.8.0-beta4</slf4j.version>
-		<openjfx.version>11.0.2</openjfx.version>
+		<openjfx.version>26</openjfx.version>
 
 	</properties>
 
@@ -177,9 +177,9 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
-					<release>11</release>
+					<source>24</source>
+					<target>24</target>
+					<release>24</release>
 				</configuration>
 				<!-- <dependencies> <dependency> <groupId>org.ow2.asm</groupId> <artifactId>asm</artifactId> <version>6.2</version> Use newer version of ASM </dependency> </dependencies> -->
 			</plugin>

--- a/org.jrebirth.af/preloader/pom.xml
+++ b/org.jrebirth.af/preloader/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/org.jrebirth.af/presentation/pom.xml
+++ b/org.jrebirth.af/presentation/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<groupId>org.jrebirth.af</groupId>
@@ -26,7 +26,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
 				<configuration>
-					<release>11</release>
+					<release>24</release>
 				</configuration>
 			</plugin>
 
@@ -76,7 +76,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/org.jrebirth.af/processor/pom.xml
+++ b/org.jrebirth.af/processor/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jrebirth.af</groupId>
@@ -57,19 +57,19 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>api</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af.tooling</groupId>
 			<artifactId>codegen</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/org.jrebirth.af/resources/pom.xml
+++ b/org.jrebirth.af/resources/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jrebirth.af</groupId>
 	<artifactId>resources</artifactId>

--- a/org.jrebirth.af/rest/pom.xml
+++ b/org.jrebirth.af/rest/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jrebirth.af</groupId>
 	<artifactId>rest</artifactId>
@@ -27,7 +27,7 @@
 						<path>
 							<groupId>org.jrebirth.af</groupId>
 							<artifactId>processor</artifactId>
-							<version>11.0.0-SNAPSHOT</version>
+							<version>12.0.0-SNAPSHOT</version>
 							<classifier>4ide</classifier>
 						</path>
 					</annotationProcessorPaths>
@@ -41,13 +41,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<classifier>4ide</classifier>
 			<optional>true</optional>
 		</dependency>

--- a/org.jrebirth.af/sample/pom.xml
+++ b/org.jrebirth.af/sample/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -65,9 +65,9 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.8.0</version>
 					<configuration>
-						<source>11</source>
-						<target>11</target>
-						<release>11</release>
+						<source>24</source>
+						<target>24</target>
+						<release>24</release>
 						<encoding>UTF-8</encoding>
 					</configuration>
 				</plugin>
@@ -129,13 +129,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>preloader</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/org.jrebirth.af/security/pom.xml
+++ b/org.jrebirth.af/security/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth</groupId>
 		<artifactId>af</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jrebirth.af</groupId>
 	<artifactId>security</artifactId>
@@ -16,13 +16,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<classifier>4ide</classifier>
 			<optional>true</optional>
 		</dependency>

--- a/org.jrebirth.af/showcase/analyzer/pom.xml
+++ b/org.jrebirth.af/showcase/analyzer/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>showcase</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	
@@ -65,9 +65,9 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.8.0</version>
 					<configuration>
-						<source>11</source>
-						<target>11</target>
-						<release>11</release>
+						<source>24</source>
+						<target>24</target>
+						<release>24</release>
 						<encoding>UTF-8</encoding>
 					</configuration>
 				</plugin>
@@ -80,7 +80,7 @@
 					<configuration>
 						<archive>
 							<manifestEntries>
-								<JavaFX-Version>8.0</JavaFX-Version>
+								<JavaFX-Version>26</JavaFX-Version>
 								<Main-Class>${appClass}</Main-Class>
 								<!--<JavaFX-Application-Class>${appClass}</JavaFX-Application-Class> -->
 							</manifestEntries>
@@ -145,7 +145,7 @@
 								</classPath>
 								<icon>${exeIcon}</icon>
 								<jre>
-									<minVersion>1.8.0</minVersion>
+									<minVersion>24</minVersion>
 									<jdkPreference>preferJre</jdkPreference>
 								</jre>
 								<versionInfo>
@@ -263,7 +263,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/org.jrebirth.af/showcase/data/pom.xml
+++ b/org.jrebirth.af/showcase/data/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>showcase</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/org.jrebirth.af/showcase/demo/pom.xml
+++ b/org.jrebirth.af/showcase/demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>showcase</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -74,7 +74,7 @@
 					<configuration>
 						<archive>
 							<manifestEntries>
-								<JavaFX-Version>11.0.0</JavaFX-Version>
+								<JavaFX-Version>26.0.0</JavaFX-Version>
 								<Main-Class>${appClass}</Main-Class>
 								<!--<JavaFX-Application-Class>${appClass}</JavaFX-Application-Class> -->
 							</manifestEntries>
@@ -139,7 +139,7 @@
 								</classPath>
 								<icon>${exeIcon}</icon>
 								<jre>
-									<minVersion>1.8.0</minVersion>
+									<minVersion>24</minVersion>
 									<jdkPreference>preferJre</jdkPreference>
 								</jre>
 								<versionInfo>
@@ -263,7 +263,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -271,41 +271,41 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>resources</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jrebirth.af.showcase</groupId>
 			<artifactId>undoredo</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jrebirth.af.showcase</groupId>
 			<artifactId>fxml</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af.showcase</groupId>
 			<artifactId>todos</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af.showcase</groupId>
 			<artifactId>fonticon</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af.showcase</groupId>
 			<artifactId>wave</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af.showcase</groupId>
 			<artifactId>workbench</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 		
 		<dependency>

--- a/org.jrebirth.af/showcase/fonticon/pom.xml
+++ b/org.jrebirth.af/showcase/fonticon/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>showcase</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -35,14 +35,14 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		
 				<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<classifier>4ide</classifier>
 			<optional>true</optional>
 		</dependency>
@@ -50,31 +50,31 @@
 		<dependency>
 			<groupId>org.jrebirth.af.iconfont-bridge</groupId>
 			<artifactId>fontawesome</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af.iconfont-bridge</groupId>
 			<artifactId>525icons</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af.iconfont-bridge</groupId>
 			<artifactId>emojione</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af.iconfont-bridge</groupId>
 			<artifactId>weathericons</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af.iconfont-bridge</groupId>
 			<artifactId>typicons</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 	</dependencies>

--- a/org.jrebirth.af/showcase/fxml/pom.xml
+++ b/org.jrebirth.af/showcase/fxml/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>showcase</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -25,12 +25,12 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>component</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/org.jrebirth.af/showcase/pom.xml
+++ b/org.jrebirth.af/showcase/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>af</artifactId>
 		<groupId>org.jrebirth</groupId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -45,7 +45,7 @@
 						<path>
 							<groupId>org.jrebirth.af</groupId>
 							<artifactId>processor</artifactId>
-							<version>11.0.0-SNAPSHOT</version>
+							<version>12.0.0-SNAPSHOT</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>
@@ -59,9 +59,9 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.8.0</version>
 					<configuration>
-						<source>11</source>
-						<target>11</target>
-						<release>11</release>
+						<source>24</source>
+						<target>24</target>
+						<release>24</release>
 						<encoding>UTF-8</encoding>
 					</configuration>
 				</plugin>
@@ -89,19 +89,19 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>preloader</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 		
 <!-- 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<classifier>tests</classifier>
 			<scope>test</scope>
 		</dependency> -->
@@ -109,13 +109,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>component</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<classifier>4ide</classifier>
 			<optional>true</optional>
 		</dependency>

--- a/org.jrebirth.af/showcase/todos/pom.xml
+++ b/org.jrebirth.af/showcase/todos/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>showcase</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -36,7 +36,7 @@
 			<plugin>
 				<groupId>org.jrebirth.af.tooling</groupId>
 				<artifactId>jrebirth-maven-plugin</artifactId>
-				<version>11.0.0-SNAPSHOT</version>
+				<version>12.0.0-SNAPSHOT</version>
 				<configuration>
 					<ecoreFile>model/Todos.ecore</ecoreFile>
 					<outputDirectory>${project.build.directory}/generated-sources/model</outputDirectory>
@@ -78,14 +78,14 @@
  		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jrebirth.af.iconfont-bridge</groupId>
 			<artifactId>fontawesome</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/org.jrebirth.af/showcase/undoredo/pom.xml
+++ b/org.jrebirth.af/showcase/undoredo/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>showcase</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -26,12 +26,12 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>undoredo</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/org.jrebirth.af/showcase/wave/pom.xml
+++ b/org.jrebirth.af/showcase/wave/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>showcase</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/org.jrebirth.af/showcase/workbench/pom.xml
+++ b/org.jrebirth.af/showcase/workbench/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>showcase</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -26,13 +26,13 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>component</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 	
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>processor</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/org.jrebirth.af/tooling/codegen/pom.xml
+++ b/org.jrebirth.af/tooling/codegen/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>tooling</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/org.jrebirth.af/tooling/ecore2fx/pom.xml
+++ b/org.jrebirth.af/tooling/ecore2fx/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>tooling</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.openjfx</groupId>
 			<artifactId>javafx-base</artifactId>
-			<version>11</version>
+			<version>26</version>
 		</dependency>
 
 		<dependency>
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af.tooling</groupId>
 			<artifactId>codegen</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 

--- a/org.jrebirth.af/tooling/genmodel/pom.xml
+++ b/org.jrebirth.af/tooling/genmodel/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>tooling</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>org.openjfx</groupId>
 			<artifactId>javafx-base</artifactId>
-			<version>11</version>
+			<version>26</version>
 		</dependency>
 	</dependencies>
 
@@ -36,7 +36,7 @@
 					<plugin>
 						<groupId>org.jrebirth.af.tooling</groupId>
 						<artifactId>jrebirth-maven-plugin</artifactId>
-						<version>11.0.0-SNAPSHOT</version>
+						<version>12.0.0-SNAPSHOT</version>
 						<configuration>
 							<ecoreFile>model/GenModel.ecore</ecoreFile>
 							<outputKind>src</outputKind>

--- a/org.jrebirth.af/tooling/jrebirth-maven-plugin/pom.xml
+++ b/org.jrebirth.af/tooling/jrebirth-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jrebirth.af</groupId>
 		<artifactId>tooling</artifactId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af.tooling</groupId>
 			<artifactId>ecore2fx</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 		
        <dependency>
@@ -69,7 +69,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
 				<configuration>
-					<release>11</release>
+					<release>24</release>
 				</configuration>
 			</plugin>
  			<plugin>

--- a/org.jrebirth.af/tooling/pom.xml
+++ b/org.jrebirth.af/tooling/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>af</artifactId>
 		<groupId>org.jrebirth</groupId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/org.jrebirth.af/transition/pom.xml
+++ b/org.jrebirth.af/transition/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>af</artifactId>
 		<groupId>org.jrebirth</groupId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<groupId>org.jrebirth.af</groupId>
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 
 	</dependencies>

--- a/org.jrebirth.af/undoredo/pom.xml
+++ b/org.jrebirth.af/undoredo/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jrebirth</groupId>
-		<version>11.0.0-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 		<artifactId>af</artifactId>
 	</parent>
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>org.jrebirth.af</groupId>
 			<artifactId>core</artifactId>
-			<version>11.0.0-SNAPSHOT</version>
+			<version>12.0.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/org.jrebirth/pom.xml
+++ b/org.jrebirth/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.jrebirth</groupId>
+	<artifactId>organization</artifactId>
+	<version>12.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<name>JRebirth Organization Parent</name>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.release>24</maven.compiler.release>
+		<java.version>24</java.version>
+	</properties>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<version>3.5.0</version>
+					<executions>
+						<execution>
+							<id>enforce-java</id>
+							<goals>
+								<goal>enforce</goal>
+							</goals>
+							<configuration>
+								<rules>
+									<requireJavaVersion>
+										<version>[24,)</version>
+										<message>JRebirth 12 requires Java 24 or newer.</message>
+									</requireJavaVersion>
+								</rules>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+</project>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- migrate all OpenJFX dependencies to version `26` across modules
- bump JRebirth module/dependency versions from `11.0.0-SNAPSHOT` (and remaining legacy `0.8.0-SNAPSHOT` in `form`) to `12.0.0-SNAPSHOT`
- raise Java compiler configuration from `11` to `24` (`source`/`target`/`release`) in parent and module-specific plugin configs
- align runtime metadata in launch/package descriptors (`JavaFX-Version`, launch4j `minVersion`) with the new JavaFX/Java baselines
- update parent inheritance for `org.jrebirth.af/pom.xml` to `org.jrebirth:organization:12.0.0-SNAPSHOT` and add a local parent POM at `org.jrebirth/pom.xml`
- enforce Java runtime baseline explicitly with `maven-enforcer-plugin` (`[24,)`)

## Testing
- `mvn -Dmaven.test.skip=true validate` (before parent switch) passed with migrated versions
- `mvn -pl api -DskipTests dependency:resolve -DincludeGroupIds=org.openjfx` resolves JavaFX `26` artifacts successfully
- `mvn -Dmaven.test.skip=true validate` (after parent+enforcer change) now fails early by design on Java < 24 with clear message: "JRebirth 12 requires Java 24 or newer."
- repository checks confirm no remaining `11.0.0-SNAPSHOT`, Java 11 compiler tags, or OpenJFX 11 versions in POM files

## Notes
- this change intentionally tightens the required runtime JDK level to 24+
- local parent POM is included so `org.jrebirth:organization:12.0.0-SNAPSHOT` resolves in-repo without relying on a remote artifact
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88ff0174-ae86-48f3-a737-021a033f9dd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88ff0174-ae86-48f3-a737-021a033f9dd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

