### PR TITLE
docs: align README with current Java, JavaFX, and Maven versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ Live feed is available on our [Blog](http://blog.jrebirth.org)
 
 ## Download & Build
 
-[ ![Download](https://api.bintray.com/packages/jrebirth/JRebirth/JRebirthAF/images/download.svg) ](https://bintray.com/jrebirth/JRebirth/JRebirthAF/_latestVersion)
+[![Maven Central](https://img.shields.io/maven-central/v/org.jrebirth.af/core.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/org.jrebirth.af/core)
 [![Build Status](http://ci.jrebirth.org/job/JRebirth-8x/badge/icon)](http://ci.jrebirth.org/job/JRebirth-8x/)
-
 
 ## Demo
 
@@ -33,12 +32,22 @@ Several Demos are available online :
 
 ## Use it
 
-Maven coordinates:
+This repository targets **Java 25**, **JavaFX 26**, and **JRebirth AF 12.0.0-SNAPSHOT** (see `org.jrebirth.af/pom.xml`).
+
+**Latest release on Maven Central** is **8.6.0** ([artifact search](https://central.sonatype.com/search?q=org.jrebirth.af)):
 
     <dependency>
         <groupId>org.jrebirth.af</groupId>
         <artifactId>core</artifactId>
         <version>8.6.0</version>
+    </dependency>
+
+To depend on this **12.x** line, build and install from source (`mvn clean install`), then use:
+
+    <dependency>
+        <groupId>org.jrebirth.af</groupId>
+        <artifactId>core</artifactId>
+        <version>12.0.0-SNAPSHOT</version>
     </dependency>
 
 ## Documentation
@@ -47,8 +56,12 @@ Documentation is available [here](http://www.jrebirth.org/doc/Toc.html).
 
 ## Build it
 
-Requires [Git](http://git-scm.com/), [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) and [Maven](http://maven.apache.org/).
+Requires [Git](http://git-scm.com/), **JDK 25** or newer, [Apache Maven](http://maven.apache.org/) **3.9+** (the build is validated against Maven 3.9.11).
 
     git clone https://github.com/JRebirth/JRebirth.git
     cd JRebirth/org.jrebirth.af
     mvn clean install
+
+To skip test compilation and execution for the full reactor (for example if a tooling module fails test compile), use:
+
+    mvn clean install -Dmaven.test.skip=true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the root `README.md` so version and tooling information matches the current multi-module build (`org.jrebirth.af/pom.xml` and `org.jrebirth/pom.xml`).

## Changes

- **Prerequisites**: JDK **25+** (enforced by organization parent), **Maven 3.9+** (build uses Maven **3.9.11** in properties), and notes **JavaFX 26** as the OpenJFX line in the parent POM.
- **Maven coordinates**: Keeps **8.6.0** as the latest **published** `org.jrebirth.af:core` on Maven Central, and documents **12.0.0-SNAPSHOT** for consumers building this branch from source.
- **Badges**: Replaces the defunct Bintray download badge with a Maven Central badge; leaves the existing Jenkins badge as-is.
- **Build**: Documents optional `mvn clean install -Dmaven.test.skip=true` for full-reactor builds when test compilation is problematic.

## Verification

Documentation-only change; no code or build execution required for this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a4b48f4-dfba-46be-9bd3-0d4d60ef5385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a4b48f4-dfba-46be-9bd3-0d4d60ef5385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

