### PR TITLE
docs/build: Maven wrapper, Enforcer (Java 25 + Maven 3.9.11), README & AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,18 @@
 
 ### Project overview
 
-JRebirth is a JavaFX application framework (multi-module Maven project). The source lives under `org.jrebirth.af/` with 18+ submodules (api, core, component, showcase, etc.). Branch `11.x-jpms` targets Java 11+ with JPMS module-info files.
+JRebirth is a JavaFX application framework (multi-module Maven project). The source lives under `org.jrebirth.af/` with many submodules (api, core, component, showcase, tooling, etc.). Active development on branch `12.x-dev` targets **Java 25** with JPMS (`module-info.java` in library and showcase modules).
+
+### Versioning
+
+- **Release line**: 12.x; Maven coordinates use version **`12.0.0-SNAPSHOT`** until a release is cut.
+- **Parent POM**: `org.jrebirth:organization` is defined in this repo at [`org.jrebirth/pom.xml`](org.jrebirth/pom.xml). The framework aggregator [`org.jrebirth.af/pom.xml`](org.jrebirth.af/pom.xml) sets `<relativePath>../org.jrebirth/pom.xml</relativePath>` — the parent is resolved from the workspace, not from an external BOM version alone.
+- **Java / JavaFX**: Compiler release and Enforcer expect **Java 25** (`java.version` / `maven.compiler.release`). OpenJFX aligns with **`openjfx.version`** (currently **26**) in the root `org.jrebirth.af` POM.
 
 ### Prerequisites
 
-- **JDK 21** (pre-installed; compiles for `--release 11`)
-- **Apache Maven 3.5.4+** (installed via `sudo apt-get install -y maven`)
+- **JDK 25** (the build uses `--release 25`; `maven-enforcer-plugin` fails the build below Java 25). If your environment only has JDK 21, install JDK 25 before running a full compile.
+- **Apache Maven 3.9+** (the POM pins `maven.version` **3.9.11** for documentation/tooling consistency; install via `sudo apt-get install -y maven` or equivalent).
 
 ### Build
 
@@ -18,7 +24,7 @@ cd /workspace/org.jrebirth.af
 mvn clean install -Dmaven.test.skip=true
 ```
 
-Use `-Dmaven.test.skip=true` to skip both test compilation and execution. The `ecore2fx` tooling submodule has a pre-existing missing JUnit 4 dependency that breaks test compilation; `-DskipTests` alone is insufficient.
+Use `-Dmaven.test.skip=true` to skip both test compilation and execution when you only need artifacts. For a normal test run from the reactor root, omit that flag (or use `-DskipTests` if you only want to skip execution).
 
 ### Running tests
 
@@ -27,7 +33,7 @@ cd /workspace/org.jrebirth.af
 mvn test -pl core
 ```
 
-Core module tests use JUnit 5, TestFX, and Monocle for headless JavaFX. On this branch (11.x-jpms), 18 of 51 core tests fail with a pre-existing JPMS `Module.getName()` NPE — this is a known framework-level issue, not an environment problem. The remaining 29 tests pass (25 pass + 4 skip).
+Core module tests use JUnit 5, TestFX, and Monocle for headless JavaFX. Run this **after** dependencies are built (e.g. following `mvn install` from the reactor root, or use `mvn test` from `org.jrebirth.af` without `-pl` if resolution errors appear). Exact skip/fail counts can change with the 12.x line; treat any widespread JPMS-related failures as framework issues to investigate in context.
 
 ### Running a showcase app
 
@@ -36,10 +42,10 @@ cd /workspace/org.jrebirth.af/showcase/demo
 DISPLAY=:1 mvn javafx:run -Djavafx.mainClass=org.jrebirth.af.showcase.demo/org.jrebirth.af.showcase.demo.JRebirthDemo
 ```
 
-Requires a running X display (`:1` via Xvfb is available in the Cloud Agent VM). The Demo app bundles all showcase modules: Wave, Undo Redo, Todos, FXML, FontIcon, Workbench.
+Requires a running X display (`:1` via Xvfb is available in the Cloud Agent VM). The Demo app bundles showcase modules such as Wave, Undo Redo, Todos, FXML, FontIcon, and Workbench.
 
 ### Gotchas
 
 - No Maven wrapper (`mvnw`) exists in the repo; Maven must be installed system-wide.
 - There is no lint command or standalone linter configured — code quality is checked via SonarQube/JaCoCo during the Maven build.
-- The parent POM `org.jrebirth:organization:2.1.1` is fetched from Maven Central on first build; internet access is required.
+- First-time builds still need **network access** to resolve dependencies from Maven Central (and other configured repositories); the organization parent itself is local under `org.jrebirth/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,18 +11,21 @@ JRebirth is a JavaFX application framework (multi-module Maven project). The sou
 - **Release line**: 12.x; Maven coordinates use version **`12.0.0-SNAPSHOT`** until a release is cut.
 - **Parent POM**: `org.jrebirth:organization` is defined in this repo at [`org.jrebirth/pom.xml`](org.jrebirth/pom.xml). The framework aggregator [`org.jrebirth.af/pom.xml`](org.jrebirth.af/pom.xml) sets `<relativePath>../org.jrebirth/pom.xml</relativePath>` — the parent is resolved from the workspace, not from an external BOM version alone.
 - **Java / JavaFX**: Compiler release and Enforcer expect **Java 25** (`java.version` / `maven.compiler.release`). OpenJFX aligns with **`openjfx.version`** (currently **26**) in the root `org.jrebirth.af` POM.
+- **Maven**: Property **`maven.version`** (**3.9.11**) is the minimum supported version; `maven-enforcer-plugin` applies **`requireMavenVersion`** with **`[${maven.version},)`** on the reactor (and on standalone builds of `org.jrebirth`).
 
 ### Prerequisites
 
-- **JDK 25** (the build uses `--release 25`; `maven-enforcer-plugin` fails the build below Java 25). If your environment only has JDK 21, install JDK 25 before running a full compile.
-- **Apache Maven 3.9+** (the POM pins `maven.version` **3.9.11** for documentation/tooling consistency; install via `sudo apt-get install -y maven` or equivalent).
+- **JDK 25** (the build uses `--release 25`; Enforcer fails below Java 25). If your environment only has JDK 21, install JDK 25 before running a full compile.
+- **Maven 3.9.11+** when using a system `mvn`, or use **`./mvnw`** from `org.jrebirth.af` (wrapper downloads Maven **3.9.11**).
 
 ### Build
 
 ```
 cd /workspace/org.jrebirth.af
-mvn clean install -Dmaven.test.skip=true
+./mvnw clean install -Dmaven.test.skip=true
 ```
+
+Prefer **`./mvnw`** so the build uses the pinned Maven version and satisfies Enforcer. A system **`mvn`** works only if its version is **3.9.11 or newer**.
 
 Use `-Dmaven.test.skip=true` to skip both test compilation and execution when you only need artifacts. For a normal test run from the reactor root, omit that flag (or use `-DskipTests` if you only want to skip execution).
 
@@ -30,22 +33,22 @@ Use `-Dmaven.test.skip=true` to skip both test compilation and execution when yo
 
 ```
 cd /workspace/org.jrebirth.af
-mvn test -pl core
+./mvnw test -pl core
 ```
 
-Core module tests use JUnit 5, TestFX, and Monocle for headless JavaFX. Run this **after** dependencies are built (e.g. following `mvn install` from the reactor root, or use `mvn test` from `org.jrebirth.af` without `-pl` if resolution errors appear). Exact skip/fail counts can change with the 12.x line; treat any widespread JPMS-related failures as framework issues to investigate in context.
+Core module tests use JUnit 5, TestFX, and Monocle for headless JavaFX. Run this **after** dependencies are built (e.g. following `./mvnw install` from the reactor root, or use `./mvnw test` from `org.jrebirth.af` without `-pl` if resolution errors appear). Exact skip/fail counts can change with the 12.x line; treat any widespread JPMS-related failures as framework issues to investigate in context.
 
 ### Running a showcase app
 
 ```
-cd /workspace/org.jrebirth.af/showcase/demo
-DISPLAY=:1 mvn javafx:run -Djavafx.mainClass=org.jrebirth.af.showcase.demo/org.jrebirth.af.showcase.demo.JRebirthDemo
+cd /workspace/org.jrebirth.af
+DISPLAY=:1 ./mvnw -pl showcase/demo javafx:run -Djavafx.mainClass=org.jrebirth.af.showcase.demo/org.jrebirth.af.showcase.demo.JRebirthDemo
 ```
 
 Requires a running X display (`:1` via Xvfb is available in the Cloud Agent VM). The Demo app bundles showcase modules such as Wave, Undo Redo, Todos, FXML, FontIcon, and Workbench.
 
 ### Gotchas
 
-- No Maven wrapper (`mvnw`) exists in the repo; Maven must be installed system-wide.
+- **Maven Wrapper**: `mvnw`, `mvnw.cmd`, and `.mvn/wrapper/` live under **`org.jrebirth.af/`**. To refresh them after bumping **`maven.version`**, run `mvn -Denforcer.skip=true -N wrapper:wrapper -Dmaven=<version>` from that directory (skip Enforcer only if your JDK is still below 25).
 - There is no lint command or standalone linter configured — code quality is checked via SonarQube/JaCoCo during the Maven build.
 - First-time builds still need **network access** to resolve dependencies from Maven Central (and other configured repositories); the organization parent itself is local under `org.jrebirth/`.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This repository targets **Java 25**, **JavaFX 26**, and **JRebirth AF 12.0.0-SNA
         <version>8.6.0</version>
     </dependency>
 
-To depend on this **12.x** line, build and install from source (`mvn clean install`), then use:
+To depend on this **12.x** line, build and install from source (`./mvnw clean install` from `org.jrebirth.af`), then use:
 
     <dependency>
         <groupId>org.jrebirth.af</groupId>
@@ -56,12 +56,20 @@ Documentation is available [here](http://www.jrebirth.org/doc/Toc.html).
 
 ## Build it
 
-Requires [Git](http://git-scm.com/), **JDK 25** or newer, [Apache Maven](http://maven.apache.org/) **3.9+** (the build is validated against Maven 3.9.11).
+Requires [Git](http://git-scm.com/), **JDK 25** or newer, and **Apache Maven 3.9.11** or newer.
+
+The reactor under `org.jrebirth.af` ships a **Maven Wrapper** (`mvnw` / `mvnw.cmd`) that downloads and uses Maven **3.9.11**, so you do not need a global Maven install for day-to-day builds:
 
     git clone https://github.com/JRebirth/JRebirth.git
     cd JRebirth/org.jrebirth.af
-    mvn clean install
+    ./mvnw clean install
 
-To skip test compilation and execution for the full reactor (for example if a tooling module fails test compile), use:
+`maven-enforcer-plugin` runs on the build and fails fast if **Java** is older than 25 or **Maven** is older than 3.9.11 (when you invoke a system `mvn` instead of the wrapper).
 
-    mvn clean install -Dmaven.test.skip=true
+To skip test compilation and execution for the full reactor:
+
+    ./mvnw clean install -Dmaven.test.skip=true
+
+To regenerate the wrapper after changing the pinned Maven version, run from `org.jrebirth.af` (use `-Denforcer.skip=true` if your JDK is below 25 and you only need to refresh wrapper files):
+
+    mvn -Denforcer.skip=true -N wrapper:wrapper -Dmaven=3.9.11

--- a/org.jrebirth.af/.mvn/wrapper/maven-wrapper.properties
+++ b/org.jrebirth.af/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/org.jrebirth.af/mvnw
+++ b/org.jrebirth.af/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/org.jrebirth.af/mvnw.cmd
+++ b/org.jrebirth.af/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/org.jrebirth.af/pom.xml
+++ b/org.jrebirth.af/pom.xml
@@ -31,6 +31,7 @@
 		<ComparisonTool-version>1.0.0-SNAPSHOT</ComparisonTool-version>
 
 		<maven.version>3.9.11</maven.version>
+		<maven.wrapper.plugin.version>3.3.4</maven.wrapper.plugin.version>
 
 		<surefire.version>3.5.5</surefire.version>
 		<slf4j.version>2.0.17</slf4j.version>
@@ -219,6 +220,11 @@
 					<artifactId>build-helper-maven-plugin</artifactId>
 					<version>${build.helper.maven.plugin.version}</version>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-wrapper-plugin</artifactId>
+					<version>${maven.wrapper.plugin.version}</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 
@@ -310,7 +316,12 @@
 							<rules>
 								<requireJavaVersion>
 									<version>[25,)</version>
+									<message>JRebirth 12 requires Java 25 or newer.</message>
 								</requireJavaVersion>
+								<requireMavenVersion>
+									<version>[${maven.version},)</version>
+									<message>JRebirth 12 requires Apache Maven ${maven.version} or newer.</message>
+								</requireMavenVersion>
 							</rules>
 						</configuration>
 					</execution>

--- a/org.jrebirth/pom.xml
+++ b/org.jrebirth/pom.xml
@@ -14,6 +14,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.release>25</maven.compiler.release>
 		<java.version>25</java.version>
+		<maven.version>3.9.11</maven.version>
 	</properties>
 
 	<build>
@@ -35,6 +36,10 @@
 										<version>[25,)</version>
 										<message>JRebirth 12 requires Java 25 or newer.</message>
 									</requireJavaVersion>
+									<requireMavenVersion>
+										<version>[${maven.version},)</version>
+										<message>JRebirth 12 requires Apache Maven ${maven.version} or newer.</message>
+									</requireMavenVersion>
 								</rules>
 							</configuration>
 						</execution>
@@ -42,5 +47,11 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+			</plugin>
+		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns contributor and agent docs with **JRebirth 12** build expectations, adds the **Maven Wrapper** under `org.jrebirth.af/`, and tightens **maven-enforcer-plugin** so builds require **Java 25** and **Maven 3.9.11+**.

## Changes

### Documentation
- **`AGENTS.md`**: Prefer `./mvnw` from `org.jrebirth.af`, document Enforcer (`requireJavaVersion` + `requireMavenVersion`), wrapper location, and showcase command via `-pl showcase/demo`.
- **`README.md`**: Build instructions use `./mvnw`, note Enforcer behavior, document regenerating the wrapper with `wrapper:wrapper`.

### Build
- **`org.jrebirth.af/`**: `mvnw`, `mvnw.cmd`, `.mvn/wrapper/maven-wrapper.properties` (Maven **3.9.11**, wrapper 3.3.4).
- **`org.jrebirth.af/pom.xml`**: `maven-wrapper-plugin` in `pluginManagement`; Enforcer adds **`requireMavenVersion`** `[${maven.version},)` with clear messages.
- **`org.jrebirth/pom.xml`**: `maven.version` property; same Enforcer rules in `pluginManagement`; **bind** `maven-enforcer-plugin` so `mvn` in `org.jrebirth/` also enforces JDK/Maven.

## Testing

- `mvn -Denforcer.skip=true -q validate` in `org.jrebirth.af` (POM validates).
- `./mvnw -version` confirms wrapper downloads and runs **Maven 3.9.11** (full reactor still requires **JDK 25** per compiler/Enforcer).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8519665-8674-43be-a4de-c90f8c43a509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8519665-8674-43be-a4de-c90f8c43a509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

